### PR TITLE
Clean-up render component draw call and remove direct shader logic references in RenderComponent

### DIFF
--- a/src/BunnyRenderComponent.cpp
+++ b/src/BunnyRenderComponent.cpp
@@ -2,8 +2,8 @@
 #include "GameObject.h"
 #include "ShaderManager.h"
 
-BunnyRenderComponent::BunnyRenderComponent(std::shared_ptr<Shape> shape, std::shared_ptr<Program> shaderProgram, std::shared_ptr<Material> material)
-	: RenderComponent(shape, shaderProgram, material) {
+BunnyRenderComponent::BunnyRenderComponent(std::shared_ptr<Shape> shape, const std::string& shaderName, std::shared_ptr<Material> material)
+	: RenderComponent(shape, shaderName, material) {
 }
 
 BunnyRenderComponent::~BunnyRenderComponent() {
@@ -12,39 +12,5 @@ BunnyRenderComponent::~BunnyRenderComponent() {
 
 void BunnyRenderComponent::draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V) {
 	ShaderManager& shaderManager = ShaderManager::instance();
-	shaderManager.renderObject(holder_, shaderProgram_->name, shape_, material_, P, V, M);
-
-	/*shaderManager.bindShader(shaderProgram_->name);
-
-	// TODO(rgarmsen2295): Add boilerplate to standard method call - probably in ShaderManager or similar
-	// Bind perspective and view tranforms
-	glUniformMatrix4fv(shaderProgram_->getUniform("P"), 1, GL_FALSE, glm::value_ptr(P->topMatrix()));
-	glUniformMatrix4fv(shaderProgram_->getUniform("V"), 1, GL_FALSE, glm::value_ptr(V->topMatrix()));
-
-	// Bind light properties
-	glUniform3f(shaderProgram_->getUniform("lightPos"), curLight.x, curLight.y, curLight.z);
-	glUniform3f(shaderProgram_->getUniform("lightClr"), curLight.r, curLight.g, curLight.b);
-
-	// Bind material properties
-	glUniform3f(shaderProgram_->getUniform("MatAmb"), material_->rAmb, material_->gAmb, material_->bAmb);
-	glUniform3f(shaderProgram_->getUniform("MatDif"), material_->rDif, material_->gDif, material_->bDif);
-	glUniform3f(shaderProgram_->getUniform("MatSpc"), material_->rSpc, material_->gSpc, material_->bSpc);
-	glUniform1f(shaderProgram_->getUniform("MatShiny"), material_->shininess);
-
-	// Set up and bind model transform
-	M->pushMatrix();
-	M->loadIdentity();
-
-	M->translate(holder_->getPosition());
-	M->scale(holder_->getScale());
-	M->rotate(holder_->getYAxisRotation(), glm::vec3(0.0f, 1.0f, 0.0f));
-
-	glUniformMatrix4fv(shaderProgram_->getUniform("M"), 1, GL_FALSE, glm::value_ptr(M->topMatrix()));
-
-	// Draw bunny
-	shape_->draw(shaderProgram_);
-
-	M->popMatrix();
-
-	shaderManager.unbindShader();*/
+	shaderManager.renderObject(holder_, shaderName_, shape_, material_, P, V, M);
 }

--- a/src/BunnyRenderComponent.cpp
+++ b/src/BunnyRenderComponent.cpp
@@ -1,5 +1,6 @@
 #include "BunnyRenderComponent.h"
 #include "GameObject.h"
+#include "ShaderManager.h"
 
 BunnyRenderComponent::BunnyRenderComponent(std::shared_ptr<Shape> shape, std::shared_ptr<Program> shaderProgram, std::shared_ptr<Material> material)
 	: RenderComponent(shape, shaderProgram, material) {
@@ -11,7 +12,9 @@ BunnyRenderComponent::~BunnyRenderComponent() {
 
 void BunnyRenderComponent::draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V) {
 	ShaderManager& shaderManager = ShaderManager::instance();
-	shaderManager.bindShader(shaderProgram_->name);
+	shaderManager.renderObject(holder_, shaderProgram_->name, shape_, material_, P, V, M);
+
+	/*shaderManager.bindShader(shaderProgram_->name);
 
 	// TODO(rgarmsen2295): Add boilerplate to standard method call - probably in ShaderManager or similar
 	// Bind perspective and view tranforms
@@ -43,5 +46,5 @@ void BunnyRenderComponent::draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<
 
 	M->popMatrix();
 
-	shaderManager.unbindShader();
+	shaderManager.unbindShader();*/
 }

--- a/src/BunnyRenderComponent.h
+++ b/src/BunnyRenderComponent.h
@@ -5,7 +5,7 @@
 
 class BunnyRenderComponent : public RenderComponent {
 public:
-	BunnyRenderComponent(std::shared_ptr<Shape> shape, std::shared_ptr<Program> shaderProgram, std::shared_ptr<Material> material);
+	BunnyRenderComponent(std::shared_ptr<Shape> shape, const std::string& shaderName, std::shared_ptr<Material> material);
 
 	~BunnyRenderComponent();
 

--- a/src/CookieThrower.cpp
+++ b/src/CookieThrower.cpp
@@ -39,7 +39,7 @@ void CookieThrower::pollAndThrow(double deltaTime, double totalTime) {
 
             CookiePhysicsComponent *cookiePhysicsComp = new CookiePhysicsComponent();
             BunnyRenderComponent *renderComp = new BunnyRenderComponent(cookieShape,
-               shaderManager.getShaderProgram("Phong"), obsidian);
+               "Phong", obsidian);
 
             glm::vec3 upDownRotAxis = glm::cross(player.direction, glm::vec3(0.0, 1.0, 0.0));
             glm::vec3 throwDirection = glm::rotate(player.direction, xRot, upDownRotAxis);

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -6,8 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-enum class GameObjectType { PLAYER, STATIC_OBJECT, DYNAMIC_OBJECT, NO_OBJECT };
-
 #include "GLSL.h"
 #include "Program.h"
 #include "MatrixStack.h"
@@ -17,6 +15,8 @@ enum class GameObjectType { PLAYER, STATIC_OBJECT, DYNAMIC_OBJECT, NO_OBJECT };
 #include "InputComponent.h"
 #include "PhysicsComponent.h"
 #include "RenderComponent.h"
+
+enum class GameObjectType { PLAYER, STATIC_OBJECT, DYNAMIC_OBJECT, NO_OBJECT };
 
 class GameObject {
 public:

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -6,6 +6,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+enum class GameObjectType { PLAYER, STATIC_OBJECT, DYNAMIC_OBJECT, NO_OBJECT };
+
 #include "GLSL.h"
 #include "Program.h"
 #include "MatrixStack.h"
@@ -15,8 +17,6 @@
 #include "InputComponent.h"
 #include "PhysicsComponent.h"
 #include "RenderComponent.h"
-
-enum class GameObjectType { PLAYER, STATIC_OBJECT, DYNAMIC_OBJECT, NO_OBJECT };
 
 class GameObject {
 public:

--- a/src/GameWorld.cpp
+++ b/src/GameWorld.cpp
@@ -1,7 +1,7 @@
 #include "GameWorld.h"
 #include "GameManager.h"
-#include "CookieThrower.h"
 #include "ShaderManager.h"
+#include "CookieThrower.h"
 #include <glm/gtx/rotate_vector.hpp>
 
 GameWorld::GameWorld()
@@ -177,7 +177,7 @@ void GameWorld::addBunnyToGameWorld() {
 	glm::vec3 initialScale(1.0f, 1.0f, 1.0f);
 
 	BunnyPhysicsComponent* bunnyPhysicsComp = new BunnyPhysicsComponent();
-	BunnyRenderComponent* bunnyRenderComp = new BunnyRenderComponent(bunnyShape, progPhong, brass);
+	BunnyRenderComponent* bunnyRenderComp = new BunnyRenderComponent(bunnyShape, "Phong", brass);
 
 	GameObject* bunnyObj = new GameObject(
 		GameObjectType::DYNAMIC_OBJECT, 

--- a/src/GameWorld.cpp
+++ b/src/GameWorld.cpp
@@ -1,6 +1,7 @@
 #include "GameWorld.h"
 #include "GameManager.h"
 #include "CookieThrower.h"
+#include "ShaderManager.h"
 #include <glm/gtx/rotate_vector.hpp>
 
 GameWorld::GameWorld()
@@ -10,6 +11,9 @@ GameWorld::GameWorld()
 
 	// Seed the PRNG with the current time for any random elements in the world
 	std::srand(std::time(NULL));
+
+	// TODO(rgarmsen2295): Make this look nicer
+	addLight({ -10.0f, 10.0f, 0.0f, 1.0f, 1.0f, 1.0f, 0.0f, 1 });
 }
 
 GameWorld::~GameWorld() {}
@@ -22,12 +26,20 @@ void GameWorld::addStaticGameObject(GameObject* obj) {
 	this->staticGameObjects_.push_back(obj);
 }
 
+void GameWorld::addLight(const Light& newLight) {
+	lights.push_back(newLight);
+}
+
 int GameWorld::getNumDynamicGameObjects() {
 	return this->dynamicGameObjects_.size();
 }
 
 int GameWorld::getNumStaticGameObjects() {
 	return this->staticGameObjects_.size();
+}
+
+const std::vector<Light>& GameWorld::getLights() {
+	return lights;
 }
 
 void GameWorld::clearGameObjects() {

--- a/src/GameWorld.h
+++ b/src/GameWorld.h
@@ -82,7 +82,7 @@ private:
 	// Collection of static geometry in the world - these should never move
 	std::vector<GameObject*> staticGameObjects_;
 
-	// A list of the lights currently in the world
+	// List of the lights currently in the world
 	std::vector<Light> lights;
 
 	// Number of "hit" bunnies

--- a/src/GameWorld.h
+++ b/src/GameWorld.h
@@ -36,12 +36,18 @@ public:
 	
 	// Adds a GameObject to the World's internal list of static GameObjects (non-moving)
 	void addStaticGameObject(GameObject* obj);
+	
+	// Adds a new light to the current world
+	void addLight(const Light& newLight);
 
 	// Gets the current total number of non-static GameObjects in the world
 	int getNumDynamicGameObjects();
 
 	// Gets the current total number of static objects in the world
 	int getNumStaticGameObjects();
+
+	// Returns a reference to the list of lights currently in the world
+	const std::vector<Light>& getLights();
 
 	// Clears the world of all GameObjects
 	void clearGameObjects();
@@ -75,6 +81,9 @@ private:
 
 	// Collection of static geometry in the world - these should never move
 	std::vector<GameObject*> staticGameObjects_;
+
+	// A list of the lights currently in the world
+	std::vector<Light> lights;
 
 	// Number of "hit" bunnies
 	int numBunniesHit;

--- a/src/PlayerRenderComponent.cpp
+++ b/src/PlayerRenderComponent.cpp
@@ -1,5 +1,6 @@
 #include "PlayerRenderComponent.h"
 #include "GameObject.h"
+#include "ShaderManager.h"
 
 PlayerRenderComponent::PlayerRenderComponent(std::shared_ptr<Shape> shape,
    std::shared_ptr<Program> shaderProgram, std::shared_ptr<Material> material)
@@ -11,34 +12,6 @@ PlayerRenderComponent::~PlayerRenderComponent() {}
 
 void PlayerRenderComponent::draw(std::shared_ptr<MatrixStack> P,
    std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V) {
-   ShaderManager& shaderManager = ShaderManager::instance();
-   shaderManager.bindShader(shaderProgram_->name);
-
-	// Bind perspective and view tranforms
-	glUniformMatrix4fv(shaderProgram_->getUniform("P"), 1, GL_FALSE, glm::value_ptr(P->topMatrix()));
-	glUniformMatrix4fv(shaderProgram_->getUniform("V"), 1, GL_FALSE, glm::value_ptr(V->topMatrix()));
-
-	// Bind light properties
-	glUniform3f(shaderProgram_->getUniform("lightPos"), curLight.x, curLight.y, curLight.z);
-	glUniform3f(shaderProgram_->getUniform("lightClr"), curLight.r, curLight.g, curLight.b);
-
-	// Bind material properties
-	glUniform3f(shaderProgram_->getUniform("MatAmb"), material_->rAmb, material_->gAmb, material_->bAmb);
-	glUniform3f(shaderProgram_->getUniform("MatDif"), material_->rDif, material_->gDif, material_->bDif);
-	glUniform3f(shaderProgram_->getUniform("MatSpc"), material_->rSpc, material_->gSpc, material_->bSpc);
-	glUniform1f(shaderProgram_->getUniform("MatShiny"), material_->shininess);
-
-	// Set up and bind model transform
-	M->pushMatrix();
-	M->loadIdentity();
-
-	M->multMatrix(holder_->transform.getTransform());
-	glUniformMatrix4fv(shaderProgram_->getUniform("M"), 1, GL_FALSE, glm::value_ptr(M->topMatrix()));
-
-	// Draw player
-	shape_->draw(shaderProgram_);
-
-	M->popMatrix();
-
-   shaderManager.unbindShader();
+	ShaderManager& shaderManager = ShaderManager::instance();
+	shaderManager.renderObject(holder_, shaderProgram_->name, shape_, material_, P, V, M);
 }

--- a/src/PlayerRenderComponent.cpp
+++ b/src/PlayerRenderComponent.cpp
@@ -3,8 +3,8 @@
 #include "ShaderManager.h"
 
 PlayerRenderComponent::PlayerRenderComponent(std::shared_ptr<Shape> shape,
-   std::shared_ptr<Program> shaderProgram, std::shared_ptr<Material> material)
-   : RenderComponent(shape, shaderProgram, material) {
+   const std::string& shaderName, std::shared_ptr<Material> material)
+   : RenderComponent(shape, shaderName, material) {
 
 }
 
@@ -13,5 +13,5 @@ PlayerRenderComponent::~PlayerRenderComponent() {}
 void PlayerRenderComponent::draw(std::shared_ptr<MatrixStack> P,
    std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V) {
 	ShaderManager& shaderManager = ShaderManager::instance();
-	shaderManager.renderObject(holder_, shaderProgram_->name, shape_, material_, P, V, M);
+	shaderManager.renderObject(holder_, shaderName_, shape_, material_, P, V, M);
 }

--- a/src/PlayerRenderComponent.h
+++ b/src/PlayerRenderComponent.h
@@ -6,7 +6,7 @@
 class PlayerRenderComponent : public RenderComponent {
 public:
    PlayerRenderComponent(std::shared_ptr<Shape> shape,
-      std::shared_ptr<Program> shaderProgram,
+      const std::string& shaderName,
       std::shared_ptr<Material> material);
 
    ~PlayerRenderComponent();

--- a/src/RenderComponent.h
+++ b/src/RenderComponent.h
@@ -14,9 +14,9 @@ class RenderComponent : public Component {
 public:
 
 	// Constructs a new RenderComponent using the passed shader program
-	RenderComponent(std::shared_ptr<Shape> shape, std::shared_ptr<Program> shaderProgram, std::shared_ptr<Material> material)
+	RenderComponent(std::shared_ptr<Shape> shape, const std::string& shaderName, std::shared_ptr<Material> material)
 		: shape_(shape), 
-		shaderProgram_(shaderProgram),
+		shaderName_(shaderName),
 		material_(material) {}
 
 	virtual ~RenderComponent() {}
@@ -36,8 +36,8 @@ protected:
 	// Shape information that is needed to draw the object
 	std::shared_ptr<Shape> shape_;
 
-	// Shader program data to use with the object
-	std::shared_ptr<Program> shaderProgram_;
+	// Shader program name set with the object
+	std::string shaderName_;
 
 	// Material that is currently in use for this object
 	std::shared_ptr<Material> material_;

--- a/src/RenderComponent.h
+++ b/src/RenderComponent.h
@@ -7,7 +7,6 @@
 #include "Shape.h"
 #include "MatrixStack.h"
 #include "ShaderHelper.h"
-#include "ShaderManager.h"
 
 #include "Component.h"
 

--- a/src/ShaderManager.h
+++ b/src/ShaderManager.h
@@ -1,12 +1,21 @@
 #ifndef SHADER_MANAGER_H
 #define SHADER_MANAGER_H
 
+#define GLEW_STATIC
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+
 #include <cassert>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <unordered_map>
 
+#include "ShaderHelper.h"
+
+#include "GameManager.h"
+#include "GameObject.h"
+#include "GameWorld.h"
 #include "GLSL.h"
 #include "Program.h"
 #include "ResourceManager.h"
@@ -46,10 +55,14 @@ public:
 
 	// Finds the shader program with the given name and binds it.
 	// Throws an |out_of_range| exception if no shader program with that name is found
-	void bindShader(const std::string& shaderProgramName);
+	const std::shared_ptr<Program> bindShader(const std::string& shaderProgramName);
 
 	// Unbinds the current shader from use
 	void unbindShader();
+
+	// Renders the given object
+	void renderObject(GameObject* objToRender, const std::string& shaderName, const std::shared_ptr<Shape> shape,
+ 	 const std::shared_ptr<Material> material, std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> V, std::shared_ptr<MatrixStack> M);
 
 private:
 

--- a/src/WallRenderComponent.cpp
+++ b/src/WallRenderComponent.cpp
@@ -2,8 +2,8 @@
 #include "GameObject.h"
 #include "ShaderManager.h"
 
-WallRenderComponent::WallRenderComponent(std::shared_ptr<Shape> shape, std::shared_ptr<Program> shaderProgram, std::shared_ptr<Material> material)
-	: RenderComponent(shape, shaderProgram, material) {
+WallRenderComponent::WallRenderComponent(std::shared_ptr<Shape> shape, const std::string& shaderName, std::shared_ptr<Material> material)
+	: RenderComponent(shape, shaderName, material) {
 
 }
 
@@ -13,5 +13,5 @@ WallRenderComponent::~WallRenderComponent() {
 
 void WallRenderComponent::draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V) {
 	ShaderManager& shaderManager = ShaderManager::instance();
-	shaderManager.renderObject(holder_, shaderProgram_->name, shape_, material_, P, V, M);
+	shaderManager.renderObject(holder_, shaderName_, shape_, material_, P, V, M);
 }

--- a/src/WallRenderComponent.cpp
+++ b/src/WallRenderComponent.cpp
@@ -1,5 +1,6 @@
 #include "WallRenderComponent.h"
 #include "GameObject.h"
+#include "ShaderManager.h"
 
 WallRenderComponent::WallRenderComponent(std::shared_ptr<Shape> shape, std::shared_ptr<Program> shaderProgram, std::shared_ptr<Material> material)
 	: RenderComponent(shape, shaderProgram, material) {
@@ -12,36 +13,5 @@ WallRenderComponent::~WallRenderComponent() {
 
 void WallRenderComponent::draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V) {
 	ShaderManager& shaderManager = ShaderManager::instance();
-	shaderManager.bindShader(shaderProgram_->name);
-
-	// Bind perspective and view tranforms
-	glUniformMatrix4fv(shaderProgram_->getUniform("P"), 1, GL_FALSE, glm::value_ptr(P->topMatrix()));
-	glUniformMatrix4fv(shaderProgram_->getUniform("V"), 1, GL_FALSE, glm::value_ptr(V->topMatrix()));
-
-	// Bind light properties
-	glUniform3f(shaderProgram_->getUniform("lightPos"), curLight.x, curLight.y, curLight.z);
-	glUniform3f(shaderProgram_->getUniform("lightClr"), curLight.r, curLight.g, curLight.b);
-
-	// Bind material properties
-	glUniform3f(shaderProgram_->getUniform("MatAmb"), material_->rAmb, material_->gAmb, material_->bAmb);
-	glUniform3f(shaderProgram_->getUniform("MatDif"), material_->rDif, material_->gDif, material_->bDif);
-	glUniform3f(shaderProgram_->getUniform("MatSpc"), material_->rSpc, material_->gSpc, material_->bSpc);
-	glUniform1f(shaderProgram_->getUniform("MatShiny"), material_->shininess);
-
-	// Set up and bind model transform
-	M->pushMatrix();
-	M->loadIdentity();
-
-	M->translate(holder_->getPosition());
-	M->scale(holder_->getScale());
-	M->rotate(holder_->getYAxisRotation(), glm::vec3(0.0f, 1.0f, 0.0f));
-
-	glUniformMatrix4fv(shaderProgram_->getUniform("M"), 1, GL_FALSE, glm::value_ptr(M->topMatrix()));
-
-	// Draw wall
-	shape_->draw(shaderProgram_);
-
-	M->popMatrix();
-
-	shaderManager.unbindShader();
+	shaderManager.renderObject(holder_, shaderProgram_->name, shape_, material_, P, V, M);
 }

--- a/src/WallRenderComponent.h
+++ b/src/WallRenderComponent.h
@@ -5,7 +5,7 @@
 
 class WallRenderComponent : public RenderComponent {
 public:
-	WallRenderComponent(std::shared_ptr<Shape> shape, std::shared_ptr<Program> shaderProgram, std::shared_ptr<Material> material);
+	WallRenderComponent(std::shared_ptr<Shape> shape, const std::string& shaderName, std::shared_ptr<Material> material);
 
 	~WallRenderComponent();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,12 +3,12 @@
  * Beginnings of a Game Engine
  */
 
+#include "ShaderManager.h"
 #include "ShaderHelper.h"
 #include "GameWorld.h"
 #include "GameManager.h"
 #include "GLFWHelper.h"
 #include "ResourceManager.h"
-#include "ShaderManager.h"
 
 #include "WallRenderComponent.h"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,12 +3,12 @@
  * Beginnings of a Game Engine
  */
 
-#include "ShaderManager.h"
 #include "ShaderHelper.h"
 #include "GameWorld.h"
 #include "GameManager.h"
 #include "GLFWHelper.h"
 #include "ResourceManager.h"
+#include "ShaderManager.h"
 
 #include "WallRenderComponent.h"
 
@@ -145,7 +145,7 @@ static void setupStaticWorld(GameWorld& world) {
 	std::shared_ptr<Program> progPhong = shaderManager.getShaderProgram("Phong");
 
 	// Floor "Wall"
-	WallRenderComponent* floorRenderComp = new WallRenderComponent(shapeCube, progPhong, green);
+	WallRenderComponent* floorRenderComp = new WallRenderComponent(shapeCube, "Phong", green);
 	GameObject* floor = new GameObject(
 		GameObjectType::STATIC_OBJECT, 
 		glm::vec3(0.0f, 0.0f, 0.0f), 
@@ -158,7 +158,7 @@ static void setupStaticWorld(GameWorld& world) {
 	world.addStaticGameObject(floor);
 
 	// Cube House 1
-	WallRenderComponent* house1RenderComp = new WallRenderComponent(shapeCube, progPhong, obsidian);
+	WallRenderComponent* house1RenderComp = new WallRenderComponent(shapeCube, "Phong", obsidian);
 	GameObject* house1 = new GameObject(
 		GameObjectType::STATIC_OBJECT, 
 		glm::vec3(-25.0f, 5.0f, -20.0f), 
@@ -171,7 +171,7 @@ static void setupStaticWorld(GameWorld& world) {
 	world.addStaticGameObject(house1);
 
 	// Cube House 2
-	WallRenderComponent* house2RenderComp = new WallRenderComponent(shapeCube, progPhong, obsidian);
+	WallRenderComponent* house2RenderComp = new WallRenderComponent(shapeCube, "Phong", obsidian);
 	GameObject* house2 = new GameObject(
 		GameObjectType::STATIC_OBJECT, 
 		glm::vec3(-30.0f, 5.0f, 20.0f), 
@@ -184,7 +184,7 @@ static void setupStaticWorld(GameWorld& world) {
 	world.addStaticGameObject(house2);
 
 	// Cube House 3
-	WallRenderComponent* house3RenderComp = new WallRenderComponent(shapeCube, progPhong, obsidian);
+	WallRenderComponent* house3RenderComp = new WallRenderComponent(shapeCube, "Phong", obsidian);
 	GameObject* house3 = new GameObject(
 		GameObjectType::STATIC_OBJECT, 
 		glm::vec3(-40.0f, 5.0f, -20.0f), 
@@ -230,7 +230,7 @@ int main(int argc, char **argv) {
    PlayerInputComponent* playerInputComp = new PlayerInputComponent();
    PlayerPhysicsComponent* playerPhysicsComp = new PlayerPhysicsComponent();
    PlayerRenderComponent* playerRenderComp = new PlayerRenderComponent(shapeGirl,
-      shaderManager.getShaderProgram("Phong"), pearl);
+      "Phong", pearl);
    GameObject* player = new GameObject(
       GameObjectType::DYNAMIC_OBJECT,
       glm::vec3(0.0f, 1.0f, 0.0f),


### PR DESCRIPTION
Okay this vastly simplifies the usual draw call and removes references to shader specific classes from the RenderComponent (now just has a key string for which shader it's running).

Not perfect, and it's late night coding, so apologies for style mistakes.

More work to be done (not 25%) in regards to refactoring shape, etc.

#5 should be done after this is merged