### PR TITLE
Moved the bounding box into the physics component for an object

### DIFF
--- a/src/BunnyPhysicsComponent.cpp
+++ b/src/BunnyPhysicsComponent.cpp
@@ -51,13 +51,6 @@ void BunnyPhysicsComponent::setupInitialRotation() {
 	holder_->setYAxisRotation(rotationAngle);
 }
 
-void BunnyPhysicsComponent::updateBoundingBox() {
-	BoundingBox& boundBox = holder_->boundBox;
-	MatrixTransform transform = holder_->transform;
-
-	boundBox.update(transform.getTransform());
-}
-
 void BunnyPhysicsComponent::updatePhysics(float deltaTime) {
 	GameWorld& world = GameManager::instance().getGameWorld();
 

--- a/src/BunnyPhysicsComponent.h
+++ b/src/BunnyPhysicsComponent.h
@@ -14,8 +14,6 @@ public:
 
 	void updatePhysics(float deltaTime);
 
-	void updateBoundingBox();
-
 private:
 
 	// Sets the initial rotation of the bunny according to it's direction vector

--- a/src/CookiePhysicsComponent.cpp
+++ b/src/CookiePhysicsComponent.cpp
@@ -19,13 +19,6 @@ void CookiePhysicsComponent::initObjectPhysics() {
     epsilon = 0.5;
 }
 
-void CookiePhysicsComponent::updateBoundingBox() {
-    BoundingBox& boundBox = holder_->boundBox;
-    MatrixTransform transform = holder_->transform;
-
-    boundBox.update(transform.getTransform());
-}
-
 void CookiePhysicsComponent::updatePhysics(float deltaTime) {
     GameWorld& world = GameManager::instance().getGameWorld();
 

--- a/src/CookiePhysicsComponent.cpp
+++ b/src/CookiePhysicsComponent.cpp
@@ -44,22 +44,22 @@ void CookiePhysicsComponent::updatePhysics(float deltaTime) {
 
     if (objTypeHit == GameObjectType::STATIC_OBJECT || objTypeHit == GameObjectType::DYNAMIC_OBJECT) {
 
-        BoundingBox objBB = objHit->boundBox;
-        BoundingBox cookieBB = holder_->boundBox;
+        BoundingBox* objBB = objHit->getBoundingBox();
+        BoundingBox* cookieBB = holder_->getBoundingBox();
 
         glm::vec3 n;
 
         //check on which side of the bounding box of the object the cookie hit and create normal for reflection
-        if((objBB.min_.x - epsilon <= cookieBB.max_.x && objBB.min_.x + epsilon >= cookieBB.max_.x) ||
-                (objBB.max_.x - epsilon <= cookieBB.min_.x && objBB.max_.x + epsilon >= cookieBB.min_.x)) {
+        if((objBB->min_.x - epsilon <= cookieBB->max_.x && objBB->min_.x + epsilon >= cookieBB->max_.x) ||
+                (objBB->max_.x - epsilon <= cookieBB->min_.x && objBB->max_.x + epsilon >= cookieBB->min_.x)) {
             n = glm::vec3(1.0, 0.0, 0.0);
         }
-        if((objBB.min_.y - epsilon <= cookieBB.max_.y && objBB.min_.y + epsilon >= cookieBB.max_.y) ||
-                (objBB.max_.y - epsilon <= cookieBB.min_.y && objBB.max_.y + epsilon >= cookieBB.min_.y)){
+        if((objBB->min_.y - epsilon <= cookieBB->max_.y && objBB->min_.y + epsilon >= cookieBB->max_.y) ||
+                (objBB->max_.y - epsilon <= cookieBB->min_.y && objBB->max_.y + epsilon >= cookieBB->min_.y)){
             n = glm::vec3(0.0, 1.0, 0.0);
         }
-        if((objBB.min_.z - epsilon <= cookieBB.max_.z && objBB.min_.z + epsilon >= cookieBB.max_.z) ||
-                (objBB.max_.z - epsilon <= cookieBB.min_.z && objBB.max_.z + epsilon >= cookieBB.min_.z)){
+        if((objBB->min_.z - epsilon <= cookieBB->max_.z && objBB->min_.z + epsilon >= cookieBB->max_.z) ||
+                (objBB->max_.z - epsilon <= cookieBB->min_.z && objBB->max_.z + epsilon >= cookieBB->min_.z)){
             n = glm::vec3(0.0, 0.0, 1.0);
         }
 

--- a/src/CookiePhysicsComponent.h
+++ b/src/CookiePhysicsComponent.h
@@ -14,8 +14,6 @@ public:
 
     void updatePhysics(float deltaTime);
 
-    void updateBoundingBox();
-
 private:
     float gravity;
     float yVelocity;

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -10,9 +10,9 @@ GameObject::GameObject(GameObjectType objType,
 	PhysicsComponent* physics,
 	RenderComponent* render,
 	ActionComponent* action)
-	: type(objType),
-	direction(glm::normalize(startDirection)),
+	: direction(glm::normalize(startDirection)),
 	velocity(startVelocity),
+	type(objType),
 	toggleMovement(false),
 	orientAngle_(0),
 	render_(render),
@@ -136,4 +136,8 @@ bool GameObject::checkIntersection(GameObject* otherObj) {
 	}
 
 	return false;
+}
+
+BoundingBox* GameObject::getBoundingBox() {
+	return &physics_->getBoundingBox();
 }

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -35,30 +35,18 @@ GameObject::GameObject(GameObjectType objType,
 		render_->setGameObjectHolder(this);
 		minBoundBoxPt = render_->getShape()->getMin();
 		maxBoundBoxPt = render_->getShape()->getMax();
-		//boundBox = BoundingBox(render_->getShape()->getMin(), render_->getShape()->getMax());
-	}
-	else {
-
-		// If no render component, set BoundingBox to min(0,0,0) -> max(0,0,0)
-		//boundBox = BoundingBox();
 	}
 
 	if (physics_ != NULL) {
 		physics_->setGameObjectHolder(this);
 		physics_->initBoundingBox(minBoundBoxPt, maxBoundBoxPt);
-		//physics_->updateBoundingBox();
 		physics_->initObjectPhysics();
-	}
-	else {
-		// TODO(rgarmsen2295): Move all bounding box stuff to base physics component class
-		//boundBox.update(transform.getTransform());
 	}
 
     if(action_ != NULL) {
         action_->setGameObjectHolder(this);
         action_->initActionComponent();
     }
-
 }
 
 GameObject::~GameObject() {

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -28,24 +28,30 @@ GameObject::GameObject(GameObjectType objType,
 	  input_->setGameObjectHolder(this);
 	}
 
+   glm::vec3 minBoundBoxPt(0.0f, 0.0f, 0.0f);
+   glm::vec3 maxBoundBoxPt(0.0f, 0.0f, 0.0f);
+
 	if (render_ != NULL) {
 		render_->setGameObjectHolder(this);
-		boundBox = BoundingBox(render_->getShape()->getMin(), render_->getShape()->getMax());
+		minBoundBoxPt = render_->getShape()->getMin();
+		maxBoundBoxPt = render_->getShape()->getMax();
+		//boundBox = BoundingBox(render_->getShape()->getMin(), render_->getShape()->getMax());
 	}
 	else {
 
 		// If no render component, set BoundingBox to min(0,0,0) -> max(0,0,0)
-		boundBox = BoundingBox();
+		//boundBox = BoundingBox();
 	}
 
 	if (physics_ != NULL) {
 		physics_->setGameObjectHolder(this);
-		physics_->updateBoundingBox();
+		physics_->initBoundingBox(minBoundBoxPt, maxBoundBoxPt);
+		//physics_->updateBoundingBox();
 		physics_->initObjectPhysics();
 	}
 	else {
 		// TODO(rgarmsen2295): Move all bounding box stuff to base physics component class
-		boundBox.update(transform.getTransform());
+		//boundBox.update(transform.getTransform());
 	}
 
     if(action_ != NULL) {
@@ -135,3 +141,11 @@ RenderComponent* GameObject::getRenderComponent() {
     return render_;
 }
 
+bool GameObject::checkIntersection(GameObject* otherObj) {	
+	PhysicsComponent* otherObjPhysics = otherObj->physics_;
+	if (physics_ != NULL && otherObjPhysics != NULL) {
+		return physics_->getBoundingBox().checkIntersection(otherObjPhysics->getBoundingBox());
+	}
+
+	return false;
+}

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -9,7 +9,6 @@
 #include "GLSL.h"
 #include "Program.h"
 #include "MatrixStack.h"
-#include "MatrixTransform.h"
 
 #include "BoundingBox.h"
 #include "InputComponent.h"
@@ -22,12 +21,20 @@ enum class GameObjectType { PLAYER, STATIC_OBJECT, DYNAMIC_OBJECT, NO_OBJECT };
 class GameObject {
 public:
 
+<<<<<<< 2d57080e041e99406e183e33394437b8a8831724
     // Direct object properties
     GameObjectType type;
     glm::vec3 direction;
     float velocity;
     MatrixTransform transform;
     BoundingBox boundBox;
+=======
+	// Direct object properties
+	glm::vec3 direction;
+	float velocity;
+	MatrixTransform transform;
+	GameObjectType type;
+>>>>>>> Initial refactor of bounding box logic
 
     // Properties for player moveable objects
     bool toggleMovement;
@@ -77,8 +84,11 @@ public:
     // Perform the any actions that are bound to the object, if any and if applicable at that moment
     void performAction(double deltaTime, double totalTime);
 
-	// Changes the shader used to draw the game object
+	// Changes the active shader for the object
 	void changeShader(const std::string& newShaderName);
+
+	// Checks if the object intersects with the passed object
+	bool checkIntersection(GameObject* otherObj);
 
 private:
 

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -21,20 +21,11 @@ enum class GameObjectType { PLAYER, STATIC_OBJECT, DYNAMIC_OBJECT, NO_OBJECT };
 class GameObject {
 public:
 
-<<<<<<< 2d57080e041e99406e183e33394437b8a8831724
-    // Direct object properties
-    GameObjectType type;
-    glm::vec3 direction;
-    float velocity;
-    MatrixTransform transform;
-    BoundingBox boundBox;
-=======
 	// Direct object properties
 	glm::vec3 direction;
 	float velocity;
 	MatrixTransform transform;
 	GameObjectType type;
->>>>>>> Initial refactor of bounding box logic
 
     // Properties for player moveable objects
     bool toggleMovement;
@@ -89,6 +80,10 @@ public:
 
 	// Checks if the object intersects with the passed object
 	bool checkIntersection(GameObject* otherObj);
+
+    // Returns the BoundingBox associated with the object if it exists, otherwise returns |NULL|
+    // TRY TO AVOID USING THIS IF POSSIBLE, SHOULD BE REMOVED AT SOME POINT, BB LOGIC ONLY IN PHYSICSCOMPONENT
+    BoundingBox* getBoundingBox();
 
 private:
 

--- a/src/GameWorld.cpp
+++ b/src/GameWorld.cpp
@@ -118,20 +118,20 @@ GameObject* GameWorld::checkCollision(GameObject* objToCheck) {
 
 
 	// Check the player against the object
-	if (player != objToCheck && objToCheck->boundBox.checkIntersection(player->boundBox)) {
+	if (player != objToCheck && objToCheck->checkIntersection(&player)) {
 		return player;
 	}
 
 	// Check against dynamic objects
 	for (GameObject* obj : dynamicGameObjects_) {
-		if (obj != objToCheck && objToCheck->boundBox.checkIntersection(obj->boundBox)) {
+		if (obj != objToCheck && objToCheck->checkIntersection(obj)) {
 			return obj;
 		}
 	}
 
 	// Check against static objects
 	for (GameObject* obj : staticGameObjects_) {
-		if (obj != objToCheck && objToCheck->boundBox.checkIntersection(obj->boundBox)) {
+		if (obj != objToCheck && objToCheck->checkIntersection(obj)) {
 			return obj;
 		}
 	}

--- a/src/GameWorld.cpp
+++ b/src/GameWorld.cpp
@@ -118,7 +118,7 @@ GameObject* GameWorld::checkCollision(GameObject* objToCheck) {
 
 
 	// Check the player against the object
-	if (player != objToCheck && objToCheck->checkIntersection(&player)) {
+	if (player != objToCheck && objToCheck->checkIntersection(player)) {
 		return player;
 	}
 

--- a/src/PhysicsComponent.cpp
+++ b/src/PhysicsComponent.cpp
@@ -1,0 +1,17 @@
+#include "PhysicsComponent.h"
+
+#include "GameObject.h"
+
+void PhysicsComponent::initBoundingBox(glm::vec3& minBoundPt, glm::vec3& maxBoundPt) {
+	boundBox_ = BoundingBox(minBoundPt, maxBoundPt);
+	updateBoundingBox();
+}
+
+void PhysicsComponent::updateBoundingBox() {
+	MatrixTransform transform = holder_->transform;
+	boundBox_.update(transform.getTransform());
+}
+
+BoundingBox& PhysicsComponent::getBoundingBox() {
+	return boundBox_;
+}

--- a/src/PhysicsComponent.h
+++ b/src/PhysicsComponent.h
@@ -1,8 +1,11 @@
 #ifndef PHYSICS_COMPONENT_H
 #define PHYSICS_COMPONENT_H
 
-#include "Component.h"
 #include <time.h>
+
+#include "BoundingBox.h"
+#include "Component.h"
+#include "MatrixTransform.h"
 
 class PhysicsComponent : public Component {
 public:
@@ -10,16 +13,25 @@ public:
 
 	virtual ~PhysicsComponent() {}
 
+	// Initializes the internal bounding box based off the passed min and max points
+	void initBoundingBox(glm::vec3& minBoundPt, glm::vec3& maxBoundPt);
+
+	// Updates the object's bounding box according to it's current MatrixStack
+	void updateBoundingBox();
+
+	// Returns a reference to the object's bounding box
+	BoundingBox& getBoundingBox();
+
 	// Initializes the object's physics specific to the implementing component
 	virtual void initObjectPhysics() = 0;
 
 	// Updates the object's physics by the given timestep |deltaTime|
 	virtual void updatePhysics(float deltaTime) = 0;
 
-	// Updates the object's bounding box according to it's current MatrixStack
-	virtual void updateBoundingBox() = 0;
-
 private:
+
+	// The bounding box associated with the object
+	BoundingBox boundBox_;
 
 };
 

--- a/src/PhysicsComponent.h
+++ b/src/PhysicsComponent.h
@@ -16,7 +16,7 @@ public:
 	// Initializes the internal bounding box based off the passed min and max points
 	void initBoundingBox(glm::vec3& minBoundPt, glm::vec3& maxBoundPt);
 
-	// Updates the object's bounding box according to it's current MatrixStack
+	// Updates the object's bounding box according to the holding object's current transform
 	void updateBoundingBox();
 
 	// Returns a reference to the object's bounding box

--- a/src/PlayerPhysicsComponent.cpp
+++ b/src/PlayerPhysicsComponent.cpp
@@ -12,13 +12,6 @@ void PlayerPhysicsComponent::initObjectPhysics() {
    updateBoundingBox();
 }
 
-void PlayerPhysicsComponent::updateBoundingBox() {
-	BoundingBox& boundBox = holder_->boundBox;
-	MatrixTransform transform = holder_->transform;
-
-	boundBox.update(transform.getTransform());
-}
-
 void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
    if (holder_->toggleMovement) {
       glm::vec3 newPosition = holder_->getPosition() + (holder_->velocity *

--- a/src/PlayerPhysicsComponent.h
+++ b/src/PlayerPhysicsComponent.h
@@ -13,8 +13,6 @@ public:
 
    void updatePhysics(float deltaTime);
 
-   void updateBoundingBox();
-
 private:
 };
 

--- a/src/WallPhysicsComponent.cpp
+++ b/src/WallPhysicsComponent.cpp
@@ -16,13 +16,6 @@ void WallPhysicsComponent::initObjectPhysics() {
 
 }
 
-void WallPhysicsComponent::updateBoundingBox() {
-    BoundingBox& boundBox = holder_->boundBox;
-    MatrixTransform transform = holder_->transform;
-
-    boundBox.update(transform.getTransform());
-}
-
 void WallPhysicsComponent::updatePhysics(float deltaTime) {
 
 }

--- a/src/WallPhysicsComponent.h
+++ b/src/WallPhysicsComponent.h
@@ -14,8 +14,6 @@ public:
 
     void updatePhysics(float deltaTime);
 
-    void updateBoundingBox();
-
 private:
 
 };


### PR DESCRIPTION
Fixes #19

Previously bounding box logic and ownership was kind of all over the place.  Now it's part of the base PhysicsComponent and is handled entirely by the physics component and accessed by the GameObject owning it occasionally for things like collision detection.

Hopefully, makes for less dumb code copying and less thinking about the bounding box outside of when to update it (which can probably be improved later).