### PR TITLE
Ported Over View Frustum Culling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ file(GLOB_RECURSE GLSL "resources/*.glsl")
 # Set the executable.
 add_executable(${CMAKE_PROJECT_NAME} ${SOURCES} ${HEADERS} ${GLSL})
 
+# Add any preprocessor definitions.
+add_definitions(-DDEBUG)
+
 # Get the GLM environment variable. Since GLM is a header-only library, we
 # just need to add it to the include directory.
 set(GLM_INCLUDE_DIR "$ENV{GLM_INCLUDE_DIR}")

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -21,6 +21,10 @@ glm::vec3& Camera::getEye() {
 	return Eye;
 }
 
+glm::vec3& Camera::getNoSpringEye() {
+   return NoSpringEye;
+}
+
 /* Eye is not added to LookAt because gaze will ultimately be LA - Eye + Eye
  * therefore we separate the LA completely. `getTarget()` will then add Eye
  * in order to create our view matrix. */
@@ -108,6 +112,7 @@ void Camera::update(float deltaTime) {
 	glm::normalize(gazeVec);
 
 	glm::vec3 w = -gazeVec;
+   NoSpringEye = player->getPosition() + w;
 
    /* Make spring calculations */
    // Ideal resting camera position

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -28,6 +28,8 @@ public:
 
 	glm::vec3& getEye();
 
+   glm::vec3& getNoSpringEye();
+
 	// Returns a reference to the current look-at vector for the camera
 	glm::vec3& getLookAt();
 
@@ -55,6 +57,7 @@ private:
 
 	// Vector's the define the camera
 	glm::vec3 Eye = glm::vec3(0, 2, 0);
+   glm::vec3 NoSpringEye;
 	glm::vec3 LA;
 	glm::vec3 Up = glm::vec3(0, 1, 0);
 

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -21,6 +21,14 @@ void GameManager::setPlayer(GameObject* newPlayer) {
    currentPlayer_ = newPlayer;
 }
 
+ViewFrustum& GameManager::getViewFrustum() {
+   return *currentViewFrustum_;
+}
+
+void GameManager::setViewFrustum(ViewFrustum* newViewFrustum) {
+   currentViewFrustum_ = newViewFrustum;
+}
+
 GameWorld& GameManager::getGameWorld() {
 	return *currentWorld_;
 }

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -3,6 +3,7 @@
 
 #include "Camera.h"
 #include "GameWorld.h"
+#include "ViewFrustum.h"
 
 // Singleton class that handles any global game state not easily categorized into other areas
 class GameManager {
@@ -25,6 +26,12 @@ public:
    // Sets a new reference to the current Player
    void setPlayer(GameObject* newPlayer);
 
+   // Gets the reference to the current View Frustum
+   ViewFrustum& getViewFrustum();
+
+   // Sets a new reference to the view frustum
+   void setViewFrustum(ViewFrustum* newViewFrustum);
+
 	// Gets the reference to the current GameWorld
 	GameWorld& getGameWorld();
 
@@ -43,6 +50,8 @@ private:
    GameObject* currentPlayer_;
 
 	GameWorld* currentWorld_;
+
+   ViewFrustum* currentViewFrustum_;
 };
 
 #endif

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -139,5 +139,8 @@ bool GameObject::checkIntersection(GameObject* otherObj) {
 }
 
 BoundingBox* GameObject::getBoundingBox() {
-	return &physics_->getBoundingBox();
+   if (physics_) {
+      return &physics_->getBoundingBox();
+   }
+	return NULL;
 }

--- a/src/GameWorld.cpp
+++ b/src/GameWorld.cpp
@@ -144,8 +144,8 @@ void GameWorld::drawVFCViewport() {
    P->ortho(-15.0f, 15.0f, -15.0f, 15.0f, 2.1f, 100.0f);
    V->pushMatrix();
    V->loadIdentity();
-   V->lookAt(camera.getEye() + glm::vec3(0, 8, 0), camera.getEye(),
-      camera.getLookAt() - camera.getEye());
+   V->lookAt(camera.getNoSpringEye() + glm::vec3(0, 8, 0), camera.getNoSpringEye(),
+      camera.getLookAt() - camera.getNoSpringEye());
 
 	// Draw non-static objects
 	for (GameObject* obj : this->dynamicGameObjects_) {

--- a/src/GameWorld.h
+++ b/src/GameWorld.h
@@ -61,6 +61,9 @@ public:
 	// Calls the draw function on all GameObjects in the world
 	void drawGameObjects();
 
+   // Draws a small view port to see view frustum culling
+   void drawVFCViewport();
+
 	// Checks to see if the passed Game Object collides with any other object in the world.
 	// Returns the type of object hit or not hit
 	GameObject* checkCollision(GameObject* objToCheck);

--- a/src/ViewFrustum.cpp
+++ b/src/ViewFrustum.cpp
@@ -1,0 +1,103 @@
+#include "ViewFrustum.h"
+
+using namespace glm;
+
+ViewFrustum::ViewFrustum() {}
+
+ViewFrustum::~ViewFrustum() {}
+
+void ViewFrustum::extractPlanes(glm::mat4 P, glm::mat4 V) {
+	/* Composite Matrix
+    * Access: mat4[col][row]
+    */
+	mat4 comp = P*V;
+	vec3 normal;     // Normal of a plane
+	float length;    // Length of the normal, used for normalization
+
+   // Left plane
+	planes[0].x = comp[0][3] + comp[0][0];
+	planes[0].y = comp[1][3] + comp[1][0];
+	planes[0].z = comp[2][3] + comp[2][0];
+	planes[0].w = comp[3][3] + comp[3][0];
+   normal = vec3(planes[0].x, planes[0].y, planes[0].z);
+   length = glm::length(normal);
+	planes[0] = planes[0] / length;
+
+   // Right plane
+	planes[1].x = comp[0][3] - comp[0][0];
+	planes[1].y = comp[1][3] - comp[1][0];
+	planes[1].z = comp[2][3] - comp[2][0];
+	planes[1].w = comp[3][3] - comp[3][0];
+   normal = vec3(planes[1].x, planes[1].y, planes[1].z);
+   length = glm::length(normal);
+	planes[1] = planes[1] / length;
+
+   // Bottom plane
+	planes[2].x = comp[0][3] + comp[0][1];
+	planes[2].y = comp[1][3] + comp[1][1];
+	planes[2].z = comp[2][3] + comp[2][1];
+	planes[2].w = comp[3][3] + comp[3][1];
+   normal = vec3(planes[2].x, planes[2].y, planes[2].z);
+   length = glm::length(normal);
+	planes[2] = planes[2] / length;
+
+   // Top plane
+	planes[3].x = comp[0][3] - comp[0][1];
+	planes[3].y = comp[1][3] - comp[1][1];
+	planes[3].z = comp[2][3] - comp[2][1];
+	planes[3].w = comp[3][3] - comp[3][1];
+   normal = vec3(planes[3].x, planes[3].y, planes[3].z);
+   length = glm::length(normal);
+	planes[3] = planes[3] / length;
+
+   // Near plane
+	planes[4].x = comp[0][3] + comp[0][2];
+	planes[4].y = comp[1][3] + comp[1][2];
+	planes[4].z = comp[2][3] + comp[2][2];
+	planes[4].w = comp[3][3] + comp[3][2];
+   normal = vec3(planes[4].x, planes[4].y, planes[4].z);
+   length = glm::length(normal);
+	planes[4] = planes[4] / length;
+	
+   // Far plane
+	planes[5].x = comp[0][3] - comp[0][2];
+	planes[5].y = comp[1][3] - comp[1][2];
+	planes[5].z = comp[2][3] - comp[2][2];
+	planes[5].w = comp[3][3] - comp[3][2];
+   normal = vec3(planes[5].x, planes[5].y, planes[5].z);
+   length = glm::length(normal);
+	planes[5] = planes[5] / length;
+}
+
+// See 'www.txutxi.com/?p=584' for detailed algorithm explanation
+bool ViewFrustum::cull(BoundingBox* b) {
+   /* Every object needs to have a bounding box in order to cull.
+    * If an object doesn't have a bounding box, cull it so we don't create
+    * unseen problems with culling. */
+   // TODO (noj) when bounding boxes get thrown in for all objs change to true
+   if (b == NULL) {
+      return false;
+   }
+   vec3 box[] = {b->min_, b->max_};
+
+   vec4 plane;
+   int px, py, pz;
+   float dotProduct;
+   for (int i = 0; i < planes.size(); ++i) {
+      plane = planes[i];
+
+      px = static_cast<int>(plane.x > 0.0f);
+      py = static_cast<int>(plane.y > 0.0f);
+      pz = static_cast<int>(plane.z > 0.0f);
+
+      dotProduct = (plane.x * box[px].x) +
+                   (plane.y * box[py].y) +
+                   (plane.z * box[pz].z);
+
+      if (dotProduct < -plane.w) {
+         return true;
+      }
+   }
+
+   return false;
+}

--- a/src/ViewFrustum.h
+++ b/src/ViewFrustum.h
@@ -1,0 +1,21 @@
+#ifndef VIEW_FRUSTUM_H
+#define VIEW_FRUSTUM_H
+
+#include "BoundingBox.h"
+#include <array>
+
+class ViewFrustum {
+public:
+   ViewFrustum();
+
+   ~ViewFrustum();
+
+   void extractPlanes(glm::mat4 P, glm::mat4 V);
+
+   bool cull(BoundingBox* box);
+
+private:
+   std::array<glm::vec4, 6> planes;
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include "ShaderHelper.h"
 #include "GameWorld.h"
 #include "GameManager.h"
+#include "ViewFrustum.h"
 #include "ResourceManager.h"
 #include "ShaderManager.h"
 #include "WindowManager.h"
@@ -325,6 +326,9 @@ int main(int argc, char **argv) {
 
     // Set the manager to the current player object
     gameManager.setPlayer(player);
+
+    // Set the current view frustum
+    gameManager.setViewFrustum(new ViewFrustum());
 
     setupStaticWorld(world);
 


### PR DESCRIPTION
Take a look at this, I tried to make ViewFrustum.h/.cpp as clean as possible so when we do end up doing a hierarchy it would be easy to have a bunch of ViewFrustum objects. I currently have a single ViewFrustum object in the GameManager, I couldn't really think of a more logical way to do it, let me know if you have any better ones.

Also I included the viewport in the bottom left corner of the screen and added a preprocessor definition around it (also updated cmake to handle this). If you don't want `DEBUG` set then edit the CMakeLists.txt to not include the debug definition.