### PR TITLE
Improved scoring

### DIFF
--- a/src/CookiePhysicsComponent.cpp
+++ b/src/CookiePhysicsComponent.cpp
@@ -74,7 +74,8 @@ void CookiePhysicsComponent::updatePhysics(float deltaTime) {
         // The color change has to be done here,
         // due to the bouncing off, the cookie never really hits the object.
         // TODO(nurgan) implement checking for object type and only change color if it is a "house"
-        if( objHit->getRenderComponent()->getShader().compare("Green")) {
+        //if( objHit->getRenderComponent()->getShader().compare("Green")) {
+        if( objHit->cookieDeliverable) {
             objHit->changeShader("Green");
             cookieState.hits++;
             cookieState.hitPosition = holder_->getPosition();

--- a/src/CookiePhysicsComponent.cpp
+++ b/src/CookiePhysicsComponent.cpp
@@ -71,14 +71,8 @@ void CookiePhysicsComponent::updatePhysics(float deltaTime) {
         holder_->setPosition(newPosition);
         updateBoundingBox();
 
-        // The color change has to be done here,
-        // due to the bouncing off, the cookie never really hits the object.
-        // TODO(nurgan) implement checking for object type and only change color if it is a "house"
-
-
         cookieState.hits++;
         cookieState.hitPositions.push_back(holder_->getPosition());
-        //if( objHit->getRenderComponent()->getShader().compare("Green")) {
         if( objHit->cookieDeliverable) {
             objHit->changeShader("Green");
             float score = calculateScore();

--- a/src/CookiePhysicsComponent.cpp
+++ b/src/CookiePhysicsComponent.cpp
@@ -17,7 +17,7 @@ void CookiePhysicsComponent::initObjectPhysics() {
     gravity = 10.0;
     yVelocity = 0.0;
     epsilon = 0.5;
-    cookieState = {0, glfwGetTime(), holder_->getPosition()};
+    cookieState = {0, glfwGetTime(), holder_->getPosition(), std::vector<glm::vec3>()};
 }
 
 void CookiePhysicsComponent::updatePhysics(float deltaTime) {
@@ -74,15 +74,18 @@ void CookiePhysicsComponent::updatePhysics(float deltaTime) {
         // The color change has to be done here,
         // due to the bouncing off, the cookie never really hits the object.
         // TODO(nurgan) implement checking for object type and only change color if it is a "house"
+
+
+        cookieState.hits++;
+        cookieState.hitPositions.push_back(holder_->getPosition());
         //if( objHit->getRenderComponent()->getShader().compare("Green")) {
         if( objHit->cookieDeliverable) {
             objHit->changeShader("Green");
-            cookieState.hits++;
-            cookieState.hitPosition = holder_->getPosition();
             float score = calculateScore();
             GameManager& gameManager = GameManager::instance();
             gameManager.reportScore(score);
             gameManager.increaseTime(score/100.0);
+            objHit->cookieDeliverable = false;
         }
 
     }
@@ -96,9 +99,7 @@ float CookiePhysicsComponent::calculateScore() {
     float score = 500.0 * cookieState.hits;
 
     //the distance multiplier
-    float distance = glm::distance(
-            glm::vec3(cookieState.launchPosition.x, 0.0, cookieState.launchPosition.z),
-            glm::vec3(cookieState.hitPosition.x, 0.0, cookieState.hitPosition.z) );
+    float distance = distanceTraveled();
 
     //TODO(nurgan) score and multiplier tweaking. distance 30 equals ~ the width of the road now.
     float distanceMultiplier = 1.0;
@@ -116,4 +117,20 @@ float CookiePhysicsComponent::calculateScore() {
 
     return score;
 
+}
+
+float CookiePhysicsComponent::distanceTraveled() {
+    // there is at least one hit
+    float distance = glm::distance(
+            glm::vec3(cookieState.launchPosition.x, 0.0, cookieState.launchPosition.z),
+            glm::vec3(cookieState.hitPositions[0].x, 0.0, cookieState.hitPositions[0].z) );
+
+    // go through all further hits
+    for(int i = 1; i < cookieState.hitPositions.size(); i++) {
+        distance += glm::distance(
+                glm::vec3(cookieState.hitPositions[i-1].x, 0.0, cookieState.hitPositions[i-1].z),
+                glm::vec3(cookieState.hitPositions[i].x, 0.0, cookieState.hitPositions[i].z) );
+    }
+
+    return distance;
 }

--- a/src/CookiePhysicsComponent.h
+++ b/src/CookiePhysicsComponent.h
@@ -1,13 +1,14 @@
 #ifndef COOKIE_PHYSICS_COMPONENT_H
 #define COOKIE_PHYSICS_COMPONENT_H
 
+#include <vector>
 #include "PhysicsComponent.h"
 
 typedef struct {
     int hits;
     double launchTime;
     glm::vec3 launchPosition;
-    glm::vec3 hitPosition;
+    std::vector<glm::vec3> hitPositions;
 } CookieState;
 
 class CookiePhysicsComponent : public PhysicsComponent {
@@ -27,6 +28,7 @@ private:
     float epsilon;
     CookieState cookieState;
     float calculateScore();
+    float distanceTraveled();
 };
 
 #endif

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -46,10 +46,8 @@ void GameManager::setTime(float time) {
 
 void GameManager::decreaseTime(float deltaTime) {
     time_ -= deltaTime;
-    std::cout << "Remaining time: " << time_ << std::endl;
 }
 
 void GameManager::increaseTime(float deltaTime) {
     time_ += deltaTime;
-    std::cout << "Remaining time: " << time_ << std::endl;
 }

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -9,7 +9,8 @@ GameObject::GameObject(GameObjectType objType,
 	InputComponent* input,
 	PhysicsComponent* physics,
 	RenderComponent* render,
-	ActionComponent* action)
+	ActionComponent* action,
+	bool deliverable)
 	: direction(glm::normalize(startDirection)),
 	velocity(startVelocity),
 	type(objType),
@@ -19,7 +20,8 @@ GameObject::GameObject(GameObjectType objType,
 	render_(render),
 	input_(input),
 	physics_(physics),
-	action_(action) {
+	action_(action),
+	cookieDeliverable(deliverable) {
 
 	// Set initial position and scale values
 	setPosition(startPosition);

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -30,6 +30,9 @@ public:
     // Properties for player moveable objects
     bool toggleMovement;
 
+	// Can a Cookie be delivered to this object
+	bool cookieDeliverable;
+
 	// Constructs a new GameObject using the given components.
 	// A NULL component will not be used
 	GameObject(GameObjectType objType,
@@ -40,7 +43,8 @@ public:
 		InputComponent* input,
 		PhysicsComponent* physics,
 		RenderComponent* render,
-		ActionComponent* action);
+		ActionComponent* action,
+		bool deliverable = false);
 
     ~GameObject();
 
@@ -110,6 +114,7 @@ private:
 
     // Action Component to control actions performed by objects
     ActionComponent* action_;
+
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,7 +137,8 @@ static void setupStaticWorld(GameWorld& world) {
 			NULL,
 			house1PhysicsComp,
 			house1RenderComp,
-	        NULL);
+	        NULL,
+            true);
 		world.addStaticGameObject(house1);
 
 		// Cube House 2
@@ -152,7 +153,8 @@ static void setupStaticWorld(GameWorld& world) {
 			NULL,
 			house2PhysicsComp,
 			house2RenderComp,
-	        NULL);
+	        NULL,
+            true);
 		world.addStaticGameObject(house2);
 
 		// Cube House 3
@@ -167,7 +169,8 @@ static void setupStaticWorld(GameWorld& world) {
 			NULL,
 			house3PhysicsComp,
 			house3RenderComp,
-	        NULL);
+	        NULL,
+            true);
 		world.addStaticGameObject(house3);
 
 		// Cube House 4
@@ -182,7 +185,8 @@ static void setupStaticWorld(GameWorld& world) {
 			NULL,
 			house4PhysicsComp,
 			house4RenderComp,
-	        NULL);
+	        NULL,
+            true);
 		world.addStaticGameObject(house4);
 
 		// Cube House 5
@@ -197,7 +201,8 @@ static void setupStaticWorld(GameWorld& world) {
 			NULL,
 			house5PhysicsComp,
 			house5RenderComp,
-	        NULL);
+	        NULL,
+            true);
 		world.addStaticGameObject(house5);
 
 		// Cube House 6
@@ -212,7 +217,8 @@ static void setupStaticWorld(GameWorld& world) {
 			NULL,
 			house6PhysicsComp,
 			house6RenderComp,
-	        NULL);
+	        NULL,
+            true);
 		world.addStaticGameObject(house6);
 
 		// Cube House 7
@@ -227,7 +233,8 @@ static void setupStaticWorld(GameWorld& world) {
 			NULL,
 			house7PhysicsComp,
 			house7RenderComp,
-	        NULL);
+	        NULL,
+            true);
 		world.addStaticGameObject(house7);
 
 		// Cube House 8
@@ -242,7 +249,8 @@ static void setupStaticWorld(GameWorld& world) {
 			NULL,
 			house8PhysicsComp,
 			house8RenderComp,
-	        NULL);
+	        NULL,
+            true);
 		world.addStaticGameObject(house8);
 
 		// Draw walls on opposite ends of map


### PR DESCRIPTION
- calculates the traveled distance of the cookie between all hits
- does not count houses that were already hit as scored hits
