### PR TITLE
Refactored GameObject pointers to shared_ptrs

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -5,7 +5,7 @@
 // Ninety degrees in radians
 constexpr float ninetyRad = 90.0f * M_PI / 180.0f;
 
-Camera::Camera(GameObject* player)
+Camera::Camera(std::shared_ptr<GameObject> player)
    : springConstant(25.0f),
    cameraDistance(5.0f),
    cameraVelocity(glm::vec3(0.0f, 0.0f, 0.0f)) {

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -22,7 +22,7 @@ public:
 	// Scale for the A and S key movements
 	const float ADScale = 10.0f;
 
-	Camera(GameObject* player);
+	Camera(std::shared_ptr<GameObject> player);
 
 	~Camera();
 
@@ -53,7 +53,7 @@ public:
 
 private:
    // The player the camera is following
-   GameObject* player;
+   std::shared_ptr<GameObject> player;
 
 	// Vector's the define the camera
 	glm::vec3 Eye = glm::vec3(0, 2, 0);

--- a/src/Component.cpp
+++ b/src/Component.cpp
@@ -1,6 +1,6 @@
 #include "Component.h"
 #include "GameObject.h"
 
-void Component::setGameObjectHolder(GameObject* holder) {
+void Component::setGameObjectHolder(std::shared_ptr<GameObject> holder) {
 	this->holder_ = holder;
 }

--- a/src/Component.h
+++ b/src/Component.h
@@ -1,6 +1,8 @@
 #ifndef COMPONENT_H
 #define COMPONENT_H
 
+#include <memory>
+
 // Forward declaration to prevent circular definition issues
 // GameObject.h must be included in any component file that uses it directly
 class GameObject;
@@ -13,12 +15,12 @@ public:
 	virtual ~Component() {}
 
 	// Sets the GameObject that is "holding" the Component
-	void setGameObjectHolder(GameObject* holder);
+	void setGameObjectHolder(std::shared_ptr<GameObject> holder);
 
 protected:
 
 	// Reference to the GameObject that uses this component (for things like position data)
-	GameObject* holder_;
+	std::shared_ptr<GameObject> holder_;
 };
 
 #endif

--- a/src/CookieActionComponent.cpp
+++ b/src/CookieActionComponent.cpp
@@ -29,40 +29,41 @@ CookieActionComponent::CookieActionComponent() {
     BunnyRenderComponent* bunnyRenderComp1 = new BunnyRenderComponent(shape, "Phong", brass);
     BunnyRenderComponent* bunnyRenderComp2 = new BunnyRenderComponent(shape, "Phong", brass);
 
-    gameObj = new GameObject(
+    gameObj = std::make_shared<GameObject>(
             GameObjectType::DYNAMIC_OBJECT,
             glm::vec3(0.0),
             glm::vec3(0.0),
             0.0,
             glm::vec3(0.1),
-            NULL,
-            NULL,
+            nullptr,
+            nullptr,
             bunnyRenderComp,
-            NULL);
+            nullptr);
+    gameObj->initComponents();
 
-    gameObj1 = new GameObject(
+    gameObj1 = std::make_shared<GameObject>(
             GameObjectType::DYNAMIC_OBJECT,
             glm::vec3(0.0),
             glm::vec3(0.0),
             0.0,
             glm::vec3(0.1),
-            NULL,
-            NULL,
+            nullptr,
+            nullptr,
             bunnyRenderComp1,
-            NULL);
+            nullptr);
+    gameObj1->initComponents();
 
-    gameObj2 = new GameObject(
+    gameObj2 = std::make_shared<GameObject>(
             GameObjectType::DYNAMIC_OBJECT,
             glm::vec3(0.0),
             glm::vec3(0.0),
             0.0,
             glm::vec3(0.1),
-            NULL,
-            NULL,
+            nullptr,
+            nullptr,
             bunnyRenderComp2,
-            NULL);
-
-
+            nullptr);
+    gameObj2->initComponents();
 }
 
 CookieActionComponent::~CookieActionComponent() {}
@@ -114,16 +115,17 @@ void CookieActionComponent::checkAndPerformAction(double deltaTime, double total
             BunnyRenderComponent *renderComp = new BunnyRenderComponent(cookieShape,
                "Phong", obsidian);
 
-            GameObject *cookieObj = new GameObject(
+            std::shared_ptr<GameObject> cookieObj = std::make_shared<GameObject>(
                     GameObjectType::DYNAMIC_OBJECT,
                     holder_->getPosition(),
                     throwDirection,
                     (holder_->velocity + startVelocity) * timeDown,
                     initialScale,
-                    NULL,
+                    nullptr,
                     cookiePhysicsComp,
                     renderComp,
-                    NULL);
+                    nullptr);
+            cookieObj->initComponents();
 
             gameManager.getGameWorld().addDynamicGameObject(cookieObj);
 

--- a/src/CookieActionComponent.h
+++ b/src/CookieActionComponent.h
@@ -28,9 +28,9 @@ public:
     void checkAndPerformAction(double deltaTime, double totalTime);
 
 private:
-    GameObject* gameObj;
-    GameObject* gameObj1;
-    GameObject* gameObj2;
+    std::shared_ptr<GameObject> gameObj;
+    std::shared_ptr<GameObject> gameObj1;
+    std::shared_ptr<GameObject> gameObj2;
     AimInputComponent* aimInputComponent;
     std::shared_ptr<Shape> cookieShape;
     float xRot = 0.0;

--- a/src/CookiePhysicsComponent.cpp
+++ b/src/CookiePhysicsComponent.cpp
@@ -40,7 +40,7 @@ void CookiePhysicsComponent::updatePhysics(float deltaTime) {
     //TODO(nurgan) make the cookie "spin" when it is in the air
 
     // If we hit anything, stop "forward"
-    GameObject* objHit = world.checkCollision(holder_);
+    std::shared_ptr<GameObject> objHit = world.checkCollision(holder_);
     GameObjectType objTypeHit = objHit->type;
 
     if (objTypeHit == GameObjectType::STATIC_OBJECT || objTypeHit == GameObjectType::DYNAMIC_OBJECT) {

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -13,11 +13,11 @@ void GameManager::setCamera(Camera* newCamera) {
 	currentCamera_ = newCamera;
 }
 
-GameObject& GameManager::getPlayer() {
-   return *currentPlayer_;
+std::shared_ptr<GameObject> GameManager::getPlayer() {
+   return currentPlayer_;
 }
 
-void GameManager::setPlayer(GameObject* newPlayer) {
+void GameManager::setPlayer(std::shared_ptr<GameObject> newPlayer) {
    currentPlayer_ = newPlayer;
 }
 

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -21,10 +21,10 @@ public:
 	void setCamera(Camera* newCamera);
 
    // Gets the reference to the current Player
-   GameObject& getPlayer();
+   std::shared_ptr<GameObject> getPlayer();
 
    // Sets a new reference to the current Player
-   void setPlayer(GameObject* newPlayer);
+   void setPlayer(std::shared_ptr<GameObject> newPlayer);
 
    // Gets the reference to the current View Frustum
    ViewFrustum& getViewFrustum();
@@ -59,7 +59,7 @@ private:
 
 	Camera* currentCamera_;
 
-   GameObject* currentPlayer_;
+   std::shared_ptr<GameObject> currentPlayer_;
 
 	GameWorld* currentWorld_;
 

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -24,34 +24,36 @@ GameObject::GameObject(GameObjectType objType,
 	// Set initial position and scale values
 	setPosition(startPosition);
 	setScale(initialScale);
+}
 
+GameObject::~GameObject() {
+
+}
+
+void GameObject::initComponents() {
 	if (input_ != NULL) {
-	  input_->setGameObjectHolder(this);
+	  input_->setGameObjectHolder(shared_from_this());
 	}
 
-   glm::vec3 minBoundBoxPt(0.0f, 0.0f, 0.0f);
-   glm::vec3 maxBoundBoxPt(0.0f, 0.0f, 0.0f);
+	glm::vec3 minBoundBoxPt(0.0f, 0.0f, 0.0f);
+	glm::vec3 maxBoundBoxPt(0.0f, 0.0f, 0.0f);
 
 	if (render_ != NULL) {
-		render_->setGameObjectHolder(this);
+		render_->setGameObjectHolder(shared_from_this());
 		minBoundBoxPt = render_->getShape()->getMin();
 		maxBoundBoxPt = render_->getShape()->getMax();
 	}
 
 	if (physics_ != NULL) {
-		physics_->setGameObjectHolder(this);
+		physics_->setGameObjectHolder(shared_from_this());
 		physics_->initBoundingBox(minBoundBoxPt, maxBoundBoxPt);
 		physics_->initObjectPhysics();
 	}
 
-    if(action_ != NULL) {
-        action_->setGameObjectHolder(this);
-        action_->initActionComponent();
-    }
-}
-
-GameObject::~GameObject() {
-
+	if (action_ != NULL) {
+	    action_->setGameObjectHolder(shared_from_this());
+	    action_->initActionComponent();
+	}
 }
 
 glm::vec3& GameObject::getPosition() {
@@ -130,7 +132,7 @@ RenderComponent* GameObject::getRenderComponent() {
     return render_;
 }
 
-bool GameObject::checkIntersection(GameObject* otherObj) {	
+bool GameObject::checkIntersection(std::shared_ptr<GameObject> otherObj) {	
 	PhysicsComponent* otherObjPhysics = otherObj->physics_;
 	if (physics_ != NULL && otherObjPhysics != NULL) {
 		return physics_->getBoundingBox().checkIntersection(otherObjPhysics->getBoundingBox());

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -18,7 +18,7 @@
 
 enum class GameObjectType { PLAYER, STATIC_OBJECT, DYNAMIC_OBJECT, NO_OBJECT };
 
-class GameObject {
+class GameObject : public std::enable_shared_from_this<GameObject> {
 public:
 
 	// Direct object properties
@@ -43,6 +43,8 @@ public:
 		ActionComponent* action);
 
     ~GameObject();
+
+    void initComponents();
 
     glm::vec3& getPosition();
 
@@ -79,7 +81,7 @@ public:
 	void changeShader(const std::string& newShaderName);
 
 	// Checks if the object intersects with the passed object
-	bool checkIntersection(GameObject* otherObj);
+	bool checkIntersection(std::shared_ptr<GameObject> otherObj);
 
     // Returns the BoundingBox associated with the object if it exists, otherwise returns |NULL|
     // TRY TO AVOID USING THIS IF POSSIBLE, SHOULD BE REMOVED AT SOME POINT, BB LOGIC ONLY IN PHYSICSCOMPONENT

--- a/src/GameWorld.cpp
+++ b/src/GameWorld.cpp
@@ -23,11 +23,11 @@ GameWorld::GameWorld()
 
 GameWorld::~GameWorld() {}
 
-void GameWorld::addDynamicGameObject(GameObject* obj) {
+void GameWorld::addDynamicGameObject(std::shared_ptr<GameObject> obj) {
 	this->dynamicGameObjects_.push_back(obj);
 }
 
-void GameWorld::addStaticGameObject(GameObject* obj) {
+void GameWorld::addStaticGameObject(std::shared_ptr<GameObject> obj) {
 	this->staticGameObjects_.push_back(obj);
 }
 
@@ -69,12 +69,12 @@ void GameWorld::updateGameObjects(double deltaTime, double totalTime) {
 	}
 #endif
 
-	for (GameObject* obj : this->dynamicGameObjects_) {
+	for (std::shared_ptr<GameObject> obj : this->dynamicGameObjects_) {
 		obj->update(deltaTime);
         obj->performAction(deltaTime, totalTime);
 	}
 
-	for (GameObject* obj : this->staticGameObjects_) {
+	for (std::shared_ptr<GameObject> obj : this->staticGameObjects_) {
 		obj->update(deltaTime);
 	}
 
@@ -106,14 +106,14 @@ void GameWorld::drawGameObjects() {
    viewFrustum.extractPlanes(P->topMatrix(), V->topMatrix());
 
 	// Draw non-static objects
-	for (GameObject* obj : this->dynamicGameObjects_) {
+	for (std::shared_ptr<GameObject> obj : this->dynamicGameObjects_) {
       if (!viewFrustum.cull(obj)) {
 		   obj->draw(P, M, V);
       }
 	}
 
 	// Draw static objects
-	for (GameObject *obj : this->staticGameObjects_) {
+	for (std::shared_ptr<GameObject> obj : this->staticGameObjects_) {
       if (!viewFrustum.cull(obj)) {
 		   obj->draw(P, M, V);
       }
@@ -148,23 +148,23 @@ void GameWorld::drawVFCViewport() {
       camera.getLookAt() - camera.getNoSpringEye());
 
 	// Draw non-static objects
-	for (GameObject* obj : this->dynamicGameObjects_) {
+	for (std::shared_ptr<GameObject> obj : this->dynamicGameObjects_) {
       if (!viewFrustum.cull(obj)) {
 		   obj->draw(P, M, V);
       }
 	}
 
 	// Draw static objects
-	for (GameObject *obj : this->staticGameObjects_) {
+	for (std::shared_ptr<GameObject> obj : this->staticGameObjects_) {
       if (!viewFrustum.cull(obj)) {
 		   obj->draw(P, M, V);
       }
 	}
 }
 
-GameObject* GameWorld::checkCollision(GameObject* objToCheck) {
+std::shared_ptr<GameObject> GameWorld::checkCollision(std::shared_ptr<GameObject> objToCheck) {
 	GameManager& gameManager = GameManager::instance();
-   GameObject* player = &gameManager.getPlayer();
+   std::shared_ptr<GameObject> player = gameManager.getPlayer();
 
 
 	// Check the player against the object
@@ -173,29 +173,29 @@ GameObject* GameWorld::checkCollision(GameObject* objToCheck) {
 	}
 
 	// Check against dynamic objects
-	for (GameObject* obj : dynamicGameObjects_) {
+	for (std::shared_ptr<GameObject> obj : dynamicGameObjects_) {
 		if (obj != objToCheck && objToCheck->checkIntersection(obj)) {
 			return obj;
 		}
 	}
 
 	// Check against static objects
-	for (GameObject* obj : staticGameObjects_) {
+	for (std::shared_ptr<GameObject> obj : staticGameObjects_) {
 		if (obj != objToCheck && objToCheck->checkIntersection(obj)) {
 			return obj;
 		}
 	}
 
-	return new GameObject(
+	return std::make_shared<GameObject>(
             GameObjectType::NO_OBJECT,
             glm::vec3(0.0),
             glm::vec3(0.0),
             0.0,
             glm::vec3(1.0),
-            NULL,
-            NULL,
-            NULL,
-            NULL);
+            nullptr,
+            nullptr,
+            nullptr,
+            nullptr);
 }
 
 unsigned long GameWorld::getRenderCount() {
@@ -246,16 +246,17 @@ void GameWorld::addBunnyToGameWorld() {
 	BunnyPhysicsComponent* bunnyPhysicsComp = new BunnyPhysicsComponent();
 	BunnyRenderComponent* bunnyRenderComp = new BunnyRenderComponent(bunnyShape, "Phong", brass);
 
-	GameObject* bunnyObj = new GameObject(
+	std::shared_ptr<GameObject> bunnyObj = std::make_shared<GameObject>(
 		GameObjectType::DYNAMIC_OBJECT, 
 		startPosition, 
 		startDirection, 
 		startVelocity, 
 		initialScale,
-		NULL, 
+		nullptr, 
 		bunnyPhysicsComp,
 		bunnyRenderComp,
-        NULL);
+        nullptr);
+	bunnyObj->initComponents();
 
 	this->addDynamicGameObject(bunnyObj);
 }

--- a/src/GameWorld.h
+++ b/src/GameWorld.h
@@ -32,10 +32,10 @@ public:
 	~GameWorld();
 
 	// Adds a GameObject to the World's internal list of non-static GameObjects (could move)
-	void addDynamicGameObject(GameObject* obj);
+	void addDynamicGameObject(std::shared_ptr<GameObject> obj);
 	
 	// Adds a GameObject to the World's internal list of static GameObjects (non-moving)
-	void addStaticGameObject(GameObject* obj);
+	void addStaticGameObject(std::shared_ptr<GameObject> obj);
 	
 	// Adds a new light to the current world
 	void addLight(const Light& newLight);
@@ -66,7 +66,7 @@ public:
 
 	// Checks to see if the passed Game Object collides with any other object in the world.
 	// Returns the type of object hit or not hit
-	GameObject* checkCollision(GameObject* objToCheck);
+	std::shared_ptr<GameObject> checkCollision(std::shared_ptr<GameObject> objToCheck);
 
 	// Returns the number of render iterations performed so far
 	unsigned long getRenderCount();
@@ -80,10 +80,10 @@ public:
 
 private:
 	// Collection of GameObjects in the world
-	std::vector<GameObject*> dynamicGameObjects_;
+	std::vector<std::shared_ptr<GameObject>> dynamicGameObjects_;
 
 	// Collection of static geometry in the world - these should never move
-	std::vector<GameObject*> staticGameObjects_;
+	std::vector<std::shared_ptr<GameObject>> staticGameObjects_;
 
 	// List of the lights currently in the world
 	std::vector<Light> lights;

--- a/src/ShaderManager.cpp
+++ b/src/ShaderManager.cpp
@@ -133,7 +133,7 @@ void ShaderManager::unbindShader() {
 	glUseProgram(NO_SHADER);
 }
 
-void ShaderManager::renderObject(GameObject* objToRender, const std::string& shaderName, const std::shared_ptr<Shape> shape,
+void ShaderManager::renderObject(std::shared_ptr<GameObject> objToRender, const std::string& shaderName, const std::shared_ptr<Shape> shape,
  const std::shared_ptr<Material> material, std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> V, std::shared_ptr<MatrixStack> M) {
 	if (objToRender != NULL) {
 		GameManager& gameManager = GameManager::instance();

--- a/src/ShaderManager.h
+++ b/src/ShaderManager.h
@@ -61,7 +61,7 @@ public:
 	void unbindShader();
 
 	// Renders the given object
-	void renderObject(GameObject* objToRender, const std::string& shaderName, const std::shared_ptr<Shape> shape,
+	void renderObject(std::shared_ptr<GameObject> objToRender, const std::string& shaderName, const std::shared_ptr<Shape> shape,
  	 const std::shared_ptr<Material> material, std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> V, std::shared_ptr<MatrixStack> M);
 
 private:

--- a/src/ViewFrustum.cpp
+++ b/src/ViewFrustum.cpp
@@ -71,7 +71,7 @@ void ViewFrustum::extractPlanes(glm::mat4 P, glm::mat4 V) {
 }
 
 // See 'www.txutxi.com/?p=584' for detailed algorithm explanation
-bool ViewFrustum::cull(GameObject* obj) {
+bool ViewFrustum::cull(std::shared_ptr<GameObject> obj) {
    /* Every object needs to have a bounding box in order to cull.
     * If an object doesn't have a bounding box, cull it so we don't create
     * unseen problems with culling. */

--- a/src/ViewFrustum.h
+++ b/src/ViewFrustum.h
@@ -12,7 +12,7 @@ public:
 
    void extractPlanes(glm::mat4 P, glm::mat4 V);
 
-   bool cull(GameObject* obj);
+   bool cull(std::shared_ptr<GameObject> obj);
 
 private:
    std::array<glm::vec4, 6> planes;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,16 +108,17 @@ static void setupStaticWorld(GameWorld& world) {
     
 	// Floor "Wall"
 	WallRenderComponent* floorRenderComp = new WallRenderComponent(shapeCube, "Phong", green);
-	GameObject* floor = new GameObject(
+	std::shared_ptr<GameObject> floor = std::make_shared<GameObject>(
 		GameObjectType::STATIC_OBJECT, 
 		glm::vec3(0.0f, 0.0f, 0.0f), 
 		glm::vec3(0.0f, 1.0f, 0.0f), 
 		0.0f, 
 		glm::vec3(1000, 0.01, 1000),
-		NULL,
-		NULL,
+		nullptr,
+		nullptr,
 		floorRenderComp,
-        NULL);
+        nullptr);
+	floor->initComponents();
 	world.addStaticGameObject(floor);
 
 	// Both sides of the current world 'miror' each other
@@ -129,196 +130,209 @@ static void setupStaticWorld(GameWorld& world) {
 		// Cube House 1
 		WallPhysicsComponent* house1PhysicsComp = new WallPhysicsComponent();
 		WallRenderComponent* house1RenderComp = new WallRenderComponent(shapeCube, "Blue", obsidian);
-		GameObject* house1 = new GameObject(
+		std::shared_ptr<GameObject> house1 = std::make_shared<GameObject>(
 			GameObjectType::STATIC_OBJECT, 
 			glm::vec3(-25.0f * i, 5.1f, -20.0f * i), 
 			glm::vec3(0.0f, 1.0f, 0.0f), 
 			0.0f,
 			glm::vec3(5, 5, 5),
-			NULL,
+			nullptr,
 			house1PhysicsComp,
 			house1RenderComp,
-	        NULL);
+	        nullptr);
+		house1->initComponents();
 		world.addStaticGameObject(house1);
 
 		// Cube House 2
 		WallPhysicsComponent* house2PhysicsComp = new WallPhysicsComponent();
 		WallRenderComponent* house2RenderComp = new WallRenderComponent(shapeCube, "Blue", obsidian);
-		GameObject* house2 = new GameObject(
+		std::shared_ptr<GameObject> house2 = std::make_shared<GameObject>(
 			GameObjectType::STATIC_OBJECT, 
 			glm::vec3(-30.0f * i, 5.1f, 20.0f * i), 
 			glm::vec3(0.0f, 1.0f, 0.0f),
 			0.0f,
 			glm::vec3(5, 5, 5),
-			NULL,
+			nullptr,
 			house2PhysicsComp,
 			house2RenderComp,
-	        NULL);
+	        nullptr);
+		house2->initComponents();
 		world.addStaticGameObject(house2);
 
 		// Cube House 3
 		WallPhysicsComponent* house3PhysicsComp = new WallPhysicsComponent();
 		WallRenderComponent* house3RenderComp = new WallRenderComponent(shapeCube, "Blue", obsidian);
-		GameObject* house3 = new GameObject(
+		std::shared_ptr<GameObject> house3 = std::make_shared<GameObject>(
 			GameObjectType::STATIC_OBJECT, 
 			glm::vec3(-40.0f * i, 5.1f, -20.0f * i), 
 			glm::vec3(0.0f, 1.0f, 0.0f),
 			0.0f,
 			glm::vec3(5, 5, 5),
-			NULL,
+			nullptr,
 			house3PhysicsComp,
 			house3RenderComp,
-	        NULL);
+	        nullptr);
+		house3->initComponents();
 		world.addStaticGameObject(house3);
 
 		// Cube House 4
 		WallPhysicsComponent* house4PhysicsComp = new WallPhysicsComponent();
 		WallRenderComponent* house4RenderComp = new WallRenderComponent(shapeCube, "Blue", obsidian);
-		GameObject* house4 = new GameObject(
+		std::shared_ptr<GameObject> house4 = std::make_shared<GameObject>(
 			GameObjectType::STATIC_OBJECT, 
 			glm::vec3(-10.0f * i, 5.1f, 20.0f * i), 
 			glm::vec3(0.0f, 1.0f, 0.0f),
 			0.0f,
 			glm::vec3(5, 5, 5),
-			NULL,
+			nullptr,
 			house4PhysicsComp,
 			house4RenderComp,
-	        NULL);
+	        nullptr);
+		house4->initComponents();
 		world.addStaticGameObject(house4);
 
 		// Cube House 5
 		WallPhysicsComponent* house5PhysicsComp = new WallPhysicsComponent();
 		WallRenderComponent* house5RenderComp = new WallRenderComponent(shapeCube, "Blue", obsidian);
-		GameObject* house5 = new GameObject(
+		std::shared_ptr<GameObject> house5 = std::make_shared<GameObject>(
 			GameObjectType::STATIC_OBJECT, 
 			glm::vec3(-60.0f * i, 5.1f, -5.0f * i), 
 			glm::vec3(0.0f, 1.0f, 0.0f),
 			0.0f,
 			glm::vec3(5, 5, 5),
-			NULL,
+			nullptr,
 			house5PhysicsComp,
 			house5RenderComp,
-	        NULL);
+	        nullptr);
+		house5->initComponents();
 		world.addStaticGameObject(house5);
 
 		// Cube House 6
 		WallPhysicsComponent* house6PhysicsComp = new WallPhysicsComponent();
 		WallRenderComponent* house6RenderComp = new WallRenderComponent(shapeCube, "Blue", obsidian);
-		GameObject* house6 = new GameObject(
+		std::shared_ptr<GameObject> house6 = std::make_shared<GameObject>(
 			GameObjectType::STATIC_OBJECT, 
 			glm::vec3(-60.0f * i, 5.1f, 15.0f * i), 
 			glm::vec3(0.0f, 1.0f, 0.0f),
 			0.0f,
 			glm::vec3(5, 5, 5),
-			NULL,
+			nullptr,
 			house6PhysicsComp,
 			house6RenderComp,
-	        NULL);
+	        nullptr);
+		house6->initComponents();
 		world.addStaticGameObject(house6);
 
 		// Cube House 7
 		WallPhysicsComponent* house7PhysicsComp = new WallPhysicsComponent();
 		WallRenderComponent* house7RenderComp = new WallRenderComponent(shapeCube, "Blue", obsidian);
-		GameObject* house7 = new GameObject(
+		std::shared_ptr<GameObject> house7 = std::make_shared<GameObject>(
 			GameObjectType::STATIC_OBJECT, 
 			glm::vec3(-60.0f * i, 5.1f, 35.0f * i), 
 			glm::vec3(0.0f, 1.0f, 0.0f),
 			0.0f,
 			glm::vec3(5, 5, 5),
-			NULL,
+			nullptr,
 			house7PhysicsComp,
 			house7RenderComp,
-	        NULL);
+	        nullptr);
+		house7->initComponents();
 		world.addStaticGameObject(house7);
 
 		// Cube House 8
 		WallPhysicsComponent* house8PhysicsComp = new WallPhysicsComponent();
 		WallRenderComponent* house8RenderComp = new WallRenderComponent(shapeCube, "Blue", obsidian);
-		GameObject* house8 = new GameObject(
+		std::shared_ptr<GameObject> house8 = std::make_shared<GameObject>(
 			GameObjectType::STATIC_OBJECT, 
 			glm::vec3(-30.0f * i, 5.1f, 45.0f * i), 
 			glm::vec3(0.0f, 1.0f, 0.0f),
 			0.0f,
 			glm::vec3(5, 5, 5),
-			NULL,
+			nullptr,
 			house8PhysicsComp,
 			house8RenderComp,
-	        NULL);
+	        nullptr);
+		house8->initComponents();
 		world.addStaticGameObject(house8);
 
 		// Draw walls on opposite ends of map
 		WallPhysicsComponent* shortWall1PhysicsComp = new WallPhysicsComponent();
 		WallRenderComponent* shortWall1RenderComp = new WallRenderComponent(shapeCube, "Green", obsidian);
-		GameObject* shortWall1 = new GameObject(
+		std::shared_ptr<GameObject> shortWall1 = std::make_shared<GameObject>(
 			GameObjectType::STATIC_OBJECT, 
 			glm::vec3(-40.0f * i, 0.5f, 45.0f * i), 
 			glm::vec3(0.0f, 1.0f, 0.0f),
 			0.0f,
 			glm::vec3(0.75, 1.0, 35),
-			NULL,
+			nullptr,
 			shortWall1PhysicsComp,
 			shortWall1RenderComp,
-	        NULL);
+	        nullptr);
+		shortWall1->initComponents();
 		world.addStaticGameObject(shortWall1);
 
 		WallPhysicsComponent* shortWall2PhysicsComp = new WallPhysicsComponent();
 		WallRenderComponent* shortWall2RenderComp = new WallRenderComponent(shapeCube, "Green", obsidian);
-		GameObject* shortWall2 = new GameObject(
+		std::shared_ptr<GameObject> shortWall2 = std::make_shared<GameObject>(
 			GameObjectType::STATIC_OBJECT, 
 			glm::vec3(-50.0f * i, 0.5f, 35.0f * i), 
 			glm::vec3(0.0f, 1.0f, 0.0f),
 			0.0f,
 			glm::vec3(0.75, 1.0, 45),
-			NULL,
+			nullptr,
 			shortWall2PhysicsComp,
 			shortWall2RenderComp,
-	        NULL);
+	        nullptr);
+		shortWall2->initComponents();
 		world.addStaticGameObject(shortWall2);
 
 		// Draw wall along center driveway
 		WallPhysicsComponent* longWallPhysicsComp = new WallPhysicsComponent();
 		WallRenderComponent* longWallRenderComp = new WallRenderComponent(shapeCube, "Green", obsidian);
-		GameObject* longWall = new GameObject(
+		std::shared_ptr<GameObject> longWall = std::make_shared<GameObject>(
 			GameObjectType::STATIC_OBJECT, 
 			glm::vec3(5.0f * i, 0.5f, 10.75f * i), 
 			glm::vec3(0.0f, 1.0f, 0.0f),
 			0.0f,
 			glm::vec3(45.5, 1.0, 0.75),
-			NULL,
+			nullptr,
 			longWallPhysicsComp,
 			longWallRenderComp,
-	        NULL);
+	        nullptr);
+		longWall->initComponents();
 		world.addStaticGameObject(longWall);
 	}
 
 	// Back wall to start location
 	WallPhysicsComponent* startWallPhysicsComp = new WallPhysicsComponent();
 	WallRenderComponent* startWallRenderComp = new WallRenderComponent(shapeCube, "Green", obsidian);
-	GameObject* startWall = new GameObject(
+	std::shared_ptr<GameObject> startWall = std::make_shared<GameObject>(
 		GameObjectType::STATIC_OBJECT, 
 		glm::vec3(45.0f, 0.5f, -79.25f), 
 		glm::vec3(0.0f, 1.0f, 0.0f),
 		0.0f,
 		glm::vec3(5, 1.0, 0.75),
-		NULL,
+		nullptr,
 		startWallPhysicsComp,
 		startWallRenderComp,
-        NULL);
+        nullptr);
+	startWall->initComponents();
 	world.addStaticGameObject(startWall);
 
 	// 'Finish' wall
 	WallPhysicsComponent* finishWallPhysicsComp = new WallPhysicsComponent();
 	WallRenderComponent* finishWallRenderComp = new WallRenderComponent(shapeCube, "Red", obsidian);
-	GameObject* finishWall = new GameObject(
+	std::shared_ptr<GameObject> finishWall = std::make_shared<GameObject>(
 		GameObjectType::STATIC_OBJECT, 
 		glm::vec3(-45.0f, 0.5f, 79.25f), 
 		glm::vec3(0.0f, 1.0f, 0.0f),
 		0.0f,
 		glm::vec3(5, 1.0, 0.75),
-		NULL,
+		nullptr,
 		finishWallPhysicsComp,
 		finishWallRenderComp,
-        NULL);
+        nullptr);
+	finishWall->initComponents();
 	world.addStaticGameObject(finishWall);
 }
 
@@ -381,7 +395,7 @@ int main(int argc, char **argv) {
     // Set the manager to the current game world
     gameManager.setGameWorld(&world);
 
-   GameObject* player = new GameObject(
+   std::shared_ptr<GameObject> player = std::make_shared<GameObject>(
       GameObjectType::PLAYER,
       glm::vec3(45.0f, 1.0f, -70.0f),
       glm::vec3(-1.0f, 0.0f, 0.0f),
@@ -392,6 +406,8 @@ int main(int argc, char **argv) {
       playerRenderComp,
 	  cookieAction
    );
+   player->initComponents();
+
    /* Set the orient angle to orient the object correctly from it's starting pos.
     * This is specific to each obj file. Positive values are cw, negative ccw */ 
    player->setYAxisRotation(-M_PI / 2);


### PR DESCRIPTION
Due to the Octree also needing pointers to GameObjs and the fact that we've been having random segfaults I decided to go ahead and move GameObjects to use `shared_ptr`.

As @joncatanio mentioned, it's not an easy 1:1 transition, with the pain point being the setting of `this` within the GameObject constructor for each component (since it now needs to be a `shared_ptr`).  There is, however, a solution by having GameObject inherit `std::enable_shared_from_this<GameObject>`.

The rub is that you can't call this until a shared_ptr of the object has already been created and GameObject's can no longer be created on the stack as a local variable.  For our game, I don't think this matters but it does mean three things.

_tl;dr_
1. The new function call in GameObject, `initComponents` *must* be called after every constructor that has components (almost all of them - minus type `NO_OBJECT`).
2. No more stack/local variables of type GameObject
3. Non-existing components must be set to `nullptr` rather than `NULL` for proper style (no warnings)

If this is a problem let me know otherwise this runs on my machine and should be good to go.  Want to merge this **ASAP** so no merge conflicts appear, this touches almost everything (please still review though!).