### PR TITLE
First-pass for player collision improvements

### DIFF
--- a/levels/grandmas-awakening.json
+++ b/levels/grandmas-awakening.json
@@ -1623,36 +1623,6 @@
          "object-name": "bubble tree",
          "object-type": "STATIC_OBJECT",
          "pos": {
-            "x": -17.0,
-            "y": 2.5,
-            "z": -50.0
-         },
-         "dir": {
-            "x": 0.0,
-            "y": 1.0,
-            "z": 0.0
-         },
-         "vel": 0.0,
-         "scale": {
-            "x": 2.5,
-            "y": 2.5,
-            "z": 2.5
-         },
-         "physics-component": {
-            "name": "WallPhysicsComponent"
-         },
-         "render-component": {
-            "name": "WallRenderComponent",
-            "shape": "BubbleTree",
-            "shader": "Phong",
-            "material": "Emerald"
-         },
-         "deliverable": false
-      },
-      {
-         "object-name": "bubble tree",
-         "object-type": "STATIC_OBJECT",
-         "pos": {
             "x": -10.0,
             "y": 7.5,
             "z": -20.0
@@ -2015,7 +1985,7 @@
          "pos": {
             "x": -20.0,
             "y": 8.5,
-            "z": -56.0
+            "z": -50.0
          },
          "dir": {
             "x": 0.0,

--- a/src/BoundingBox.cpp
+++ b/src/BoundingBox.cpp
@@ -37,26 +37,24 @@ bool BoundingBox::checkIntersection(BoundingBox& other) {
 }
 
 glm::vec3 BoundingBox::calcReflNormal(BoundingBox& other) {
-   glm::vec3 normal;
+   glm::vec3 normal = glm::vec3(0.0, 0.0, 0.0);
    float epsilon = 1.5;
 
    //check on which side of the bounding box of the object the cookie hit and create normal for reflection
    if((this->min_.x - epsilon <= other.max_.x && this->min_.x + epsilon >= other.max_.x) ||
            (this->max_.x - epsilon <= other.min_.x && this->max_.x + epsilon >= other.min_.x)) {
-       normal = glm::vec3(1.0, 0.0, 0.0);
+       normal.x = 1.0;
    }
    if((this->min_.y - epsilon <= other.max_.y && this->min_.y + epsilon >= other.max_.y) ||
            (this->max_.y - epsilon <= other.min_.y && this->max_.y + epsilon >= other.min_.y)){
-
-       // TODO(rgarmsen2295): Hack, should be y as normal, figure out why collisions are matching x instead of y only
-       normal = glm::vec3(1.0, 0.0, 0.0);
+       normal.y = 1.0;
    }
    if((this->min_.z - epsilon <= other.max_.z && this->min_.z + epsilon >= other.max_.z) ||
            (this->max_.z - epsilon <= other.min_.z && this->max_.z + epsilon >= other.min_.z)){
-       normal = glm::vec3(0.0, 0.0, 1.0);
+       normal.z = 1.0;
    }
 
-   return normal;
+   return glm::normalize(normal);
 }
 
 void BoundingBox::update(glm::mat4& transform) {

--- a/src/BoundingBox.cpp
+++ b/src/BoundingBox.cpp
@@ -47,7 +47,9 @@ glm::vec3 BoundingBox::calcReflNormal(BoundingBox& other) {
    }
    if((this->min_.y - epsilon <= other.max_.y && this->min_.y + epsilon >= other.max_.y) ||
            (this->max_.y - epsilon <= other.min_.y && this->max_.y + epsilon >= other.min_.y)){
-       normal = glm::vec3(0.0, 1.0, 0.0);
+   	
+   		// TODO(rgarmsen2295): Hack, should be y as normal, figure out why collisions are matching x instead of y only
+       normal = glm::vec3(1.0, 0.0, 0.0);
    }
    if((this->min_.z - epsilon <= other.max_.z && this->min_.z + epsilon >= other.max_.z) ||
            (this->max_.z - epsilon <= other.min_.z && this->max_.z + epsilon >= other.min_.z)){

--- a/src/BoundingBox.cpp
+++ b/src/BoundingBox.cpp
@@ -47,8 +47,8 @@ glm::vec3 BoundingBox::calcReflNormal(BoundingBox& other) {
    }
    if((this->min_.y - epsilon <= other.max_.y && this->min_.y + epsilon >= other.max_.y) ||
            (this->max_.y - epsilon <= other.min_.y && this->max_.y + epsilon >= other.min_.y)){
-   	
-   		// TODO(rgarmsen2295): Hack, should be y as normal, figure out why collisions are matching x instead of y only
+
+       // TODO(rgarmsen2295): Hack, should be y as normal, figure out why collisions are matching x instead of y only
        normal = glm::vec3(1.0, 0.0, 0.0);
    }
    if((this->min_.z - epsilon <= other.max_.z && this->min_.z + epsilon >= other.max_.z) ||

--- a/src/BunnyPhysicsComponent.cpp
+++ b/src/BunnyPhysicsComponent.cpp
@@ -19,11 +19,12 @@ void BunnyPhysicsComponent::initObjectPhysics() {
 	setupInitialRotation();
 	updateBoundingBox();
 
-	std::shared_ptr<GameObject> objHit = world.checkCollision(holder_);
+	std::vector<std::shared_ptr<GameObject>> objsHit = world.checkCollision(holder_);
 
 	// Don't randomly place a bunny on another bunny
 	// Bunnies with no direction (static at 0, 0, 0) are currently OK - rare and adds an interesting twist
-	while (objHit != nullptr) {
+	while (!objsHit.empty()) {
+		std::shared_ptr<GameObject> objHit = objsHit[0];
 
 		// Get a random start location between (-10, 0, -10) and (10, 0, 10)
 		float randomStartX = (std::rand() % 20) - 10.0f;
@@ -39,7 +40,7 @@ void BunnyPhysicsComponent::initObjectPhysics() {
 		setupInitialRotation();
 		updateBoundingBox();
 
-		objHit = world.checkCollision(holder_);
+		objsHit = world.checkCollision(holder_);
 	}
 }
 
@@ -63,8 +64,9 @@ void BunnyPhysicsComponent::updatePhysics(float deltaTime) {
 	updateBoundingBox();
 
 	// If we hit someone or we're at the edge of the acceptable "world", then reverse direction
-	std::shared_ptr<GameObject> objHit = world.checkCollision(holder_);
-	if (objHit != nullptr) {
+	std::vector<std::shared_ptr<GameObject>> objsHit = world.checkCollision(holder_);
+	if (!objsHit.empty()) {
+		std::shared_ptr<GameObject> objHit = objsHit[0];
 		GameObjectType objTypeHit = objHit->type;
 
 		if (objTypeHit == GameObjectType::PLAYER) {

--- a/src/CookiePhysicsComponent.cpp
+++ b/src/CookiePhysicsComponent.cpp
@@ -41,8 +41,9 @@ void CookiePhysicsComponent::updatePhysics(float deltaTime) {
     //TODO(nurgan) make the cookie "spin" when it is in the air
 
     // If we hit anything, stop "forward"
-    std::shared_ptr<GameObject> objHit = world.checkCollision(holder_);
-    if (objHit != nullptr) {
+    std::vector<std::shared_ptr<GameObject>> objsHit = world.checkCollision(holder_);
+    if (!objsHit.empty()) {
+        std::shared_ptr<GameObject> objHit = objsHit[0];
         GameObjectType objTypeHit = objHit->type;
 
         if (objTypeHit == GameObjectType::STATIC_OBJECT || objTypeHit == GameObjectType::DYNAMIC_OBJECT) {

--- a/src/FireHydrantPhysicsComponent.cpp
+++ b/src/FireHydrantPhysicsComponent.cpp
@@ -15,7 +15,6 @@ void FireHydrantPhysicsComponent::initObjectPhysics() {
 
 void FireHydrantPhysicsComponent::updatePhysics(float deltaTime) {
    GameWorld& world = GameManager::instance().getGameWorld();
-   std::shared_ptr<GameObject> objHit = world.checkCollision(holder_);
 
    glm::vec3 oldPosition = holder_->getPosition();
    glm::vec3 newPosition = holder_->getPosition() + (holder_->velocity *
@@ -32,7 +31,9 @@ void FireHydrantPhysicsComponent::updatePhysics(float deltaTime) {
       holder_->velocity = 0.0f;
    }
 
-   if (objHit != nullptr) {
+   std::vector<std::shared_ptr<GameObject>> objsHit = world.checkCollision(holder_);
+   if (!objsHit.empty()) {
+      std::shared_ptr<GameObject> objHit = objsHit[0];
       GameObjectType objTypeHit = objHit->type;
       
       if (objTypeHit == GameObjectType::PLAYER) {

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -55,7 +55,7 @@ void GameManager::setTime(float time) {
 void GameManager::decreaseTime(float deltaTime) {
     time_ -= deltaTime;
 	if(time_ <= 0.0) {
-		//gameOver_ = true;
+		gameOver_ = true;
 	}
 }
 

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -55,7 +55,7 @@ void GameManager::setTime(float time) {
 void GameManager::decreaseTime(float deltaTime) {
     time_ -= deltaTime;
 	if(time_ <= 0.0) {
-		gameOver_ = true;
+		//gameOver_ = true;
 	}
 }
 

--- a/src/GameWorld.cpp
+++ b/src/GameWorld.cpp
@@ -204,29 +204,33 @@ void GameWorld::drawVFCViewport() {
 	}
 }
 
-std::shared_ptr<GameObject> GameWorld::checkCollision(std::shared_ptr<GameObject> objToCheck) {
+std::vector<std::shared_ptr<GameObject>> GameWorld::checkCollision(std::shared_ptr<GameObject> objToCheck) {
 	GameManager& gameManager = GameManager::instance();
+	std::vector<std::shared_ptr<GameObject>> collidedObjs;
+
    std::shared_ptr<GameObject> player = gameManager.getPlayer();
 
 	// Check the player against the object
 	if (player != objToCheck && objToCheck->checkIntersection(player)) {
-		return player;
+		collidedObjs.push_back(player);
 	}
 
 	// Check against dynamic objects
 	for (std::shared_ptr<GameObject> obj : dynamicGameObjects_) {
 		if (obj != objToCheck && objToCheck->checkIntersection(obj)) {
-			return obj;
+			collidedObjs.push_back(obj);
 		}
 	}
 
 	// Check against static objects
-	std::shared_ptr<GameObject> objHit = staticGameObjectsTree_.checkIntersection(objToCheck);
-	if (objHit != nullptr) {
-		return objHit;
+	std::vector<std::shared_ptr<GameObject>> staticObjsCollided = staticGameObjectsTree_.checkIntersection(objToCheck);
+	if (!staticObjsCollided.empty()) {
+		collidedObjs.insert(collidedObjs.end(), 
+		 std::make_move_iterator(staticObjsCollided.begin()),
+		 std::make_move_iterator(staticObjsCollided.end()));
 	}
 
-	return nullptr;
+	return collidedObjs;
 }
 
 unsigned long GameWorld::getRenderCount() {

--- a/src/GameWorld.h
+++ b/src/GameWorld.h
@@ -3,6 +3,8 @@
 
 #include <ctime>
 #include <iostream>
+#include <iterator>
+#include <vector>
 #include <queue>
 
 #include <stdio.h>
@@ -87,8 +89,8 @@ public:
    void drawVFCViewport();
 
 	// Checks to see if the passed Game Object collides with any other object in the world.
-	// Returns the type of object hit or not hit
-	std::shared_ptr<GameObject> checkCollision(std::shared_ptr<GameObject> objToCheck);
+	// Returns an array of all objects collided with
+	std::vector<std::shared_ptr<GameObject>> checkCollision(std::shared_ptr<GameObject> objToCheck);
 
 	// Returns the number of render iterations performed so far
 	unsigned long getRenderCount();

--- a/src/OctreeNode.cpp
+++ b/src/OctreeNode.cpp
@@ -84,7 +84,6 @@ std::vector<std::shared_ptr<GameObject>> OctreeNode::checkIntersection(std::shar
    // Check for a child that contains the object and recursively call it's |checkIntersection| method
    for (OctreeNode& child : children_) {
       if (child.contains(objToCheck)) {
-         //hitObj = child.checkIntersection(objToCheck);
          std::vector<std::shared_ptr<GameObject>> childHitObjs = child.checkIntersection(objToCheck);
          hitObjs.insert(hitObjs.end(), 
           std::make_move_iterator(childHitObjs.begin()),
@@ -93,14 +92,12 @@ std::vector<std::shared_ptr<GameObject>> OctreeNode::checkIntersection(std::shar
       }
    }
 
-   // Nothing hit yet, so check all the objects belonging to this node
-   //if (hitObjs.empty()) {
-      for (std::shared_ptr<GameObject> objInTree : objsEnclosed_) {
-         if (objToCheck->checkIntersection(objInTree)) {
-            hitObjs.push_back(objInTree);
-         }
+   // Check all the objects belonging to this node (since the object must be contained within)
+   for (std::shared_ptr<GameObject> objInTree : objsEnclosed_) {
+      if (objToCheck->checkIntersection(objInTree)) {
+         hitObjs.push_back(objInTree);
       }
-   //}
+   }
 
    return hitObjs;
 }

--- a/src/OctreeNode.cpp
+++ b/src/OctreeNode.cpp
@@ -78,28 +78,31 @@ void OctreeNode::clearTree() {
    objsEnclosed_.clear();
 }
 
-std::shared_ptr<GameObject> OctreeNode::checkIntersection(std::shared_ptr<GameObject> objToCheck) {
-   std::shared_ptr<GameObject> hitObj = nullptr;
+std::vector<std::shared_ptr<GameObject>> OctreeNode::checkIntersection(std::shared_ptr<GameObject> objToCheck) {
+   std::vector<std::shared_ptr<GameObject>> hitObjs;
 
    // Check for a child that contains the object and recursively call it's |checkIntersection| method
    for (OctreeNode& child : children_) {
       if (child.contains(objToCheck)) {
-         hitObj = child.checkIntersection(objToCheck);
+         //hitObj = child.checkIntersection(objToCheck);
+         std::vector<std::shared_ptr<GameObject>> childHitObjs = child.checkIntersection(objToCheck);
+         hitObjs.insert(hitObjs.end(), 
+          std::make_move_iterator(childHitObjs.begin()),
+          std::make_move_iterator(childHitObjs.end()));
          break;
       }
    }
 
    // Nothing hit yet, so check all the objects belonging to this node
-   if (hitObj == nullptr) {
+   //if (hitObjs.empty()) {
       for (std::shared_ptr<GameObject> objInTree : objsEnclosed_) {
          if (objToCheck->checkIntersection(objInTree)) {
-            hitObj = objInTree;
-            break;
+            hitObjs.push_back(objInTree);
          }
       }
-   }
+   //}
 
-   return hitObj;
+   return hitObjs;
 }
    
 void OctreeNode::buildTreeNode() {

--- a/src/OctreeNode.h
+++ b/src/OctreeNode.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <list>
 #include <memory>
+#include <vector>
 #include <queue>
 
 #include "glm/glm.hpp"
@@ -36,7 +37,7 @@ public:
    void clearTree();
 
    // Returns an object that intersects with the past object. Returns |nullptr| if no such object exists
-   std::shared_ptr<GameObject> checkIntersection(std::shared_ptr<GameObject> objToCheck);
+   std::vector<std::shared_ptr<GameObject>> checkIntersection(std::shared_ptr<GameObject> objToCheck);
 
 private:
 

--- a/src/PlayerPhysicsComponent.cpp
+++ b/src/PlayerPhysicsComponent.cpp
@@ -25,31 +25,42 @@ void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
       GameWorld& world = GameManager::instance().getGameWorld();
       std::vector<std::shared_ptr<GameObject>> objsHit = world.checkCollision(holder_);
 
-      if (!objsHit.empty()) {
+      /*if (!objsHit.empty()) {
          std::shared_ptr<GameObject> objHit = objsHit[0];
-         if (objHit != nullptr) {
-            GameObjectType objTypeHit = objHit->type;
+         if (objHit != nullptr) {*/
+      for (auto objHit : objsHit) {
+         GameObjectType objTypeHit = objHit->type;
 
-            if (objTypeHit == GameObjectType::STATIC_OBJECT) {
-               BoundingBox* objHitBB = objHit->getBoundingBox();
-               glm::vec3 normalOfObjHit = objHitBB->calcReflNormal(getBoundingBox());
+         if (objTypeHit == GameObjectType::STATIC_OBJECT) {
+            BoundingBox* objHitBB = objHit->getBoundingBox();
+            glm::vec3 normalOfObjHit = objHitBB->calcReflNormal(getBoundingBox());
 
-               if (normalOfObjHit.x != 0.0f) {
-                  newPosition.x = oldPosition.x;
-               }
-
-               if (normalOfObjHit.z != 0.0f) {
-                  newPosition.z = oldPosition.z;
-               }
-
-               holder_->setPosition(newPosition);
-               updateBoundingBox();
+            if (normalOfObjHit.x != 0.0f) {
+         std::cout << "HERE X!" << std::endl;
+               newPosition.x = oldPosition.x;
             }
-            if (objTypeHit == GameObjectType::FINISH_OBJECT) {
-               GameManager::instance().gameOver_ = true;
+
+            if (normalOfObjHit.y != 0.0f) {
+         std::cout << "HERE Y!" << std::endl;
+               newPosition.y = oldPosition.y;
+            }
+
+            if (normalOfObjHit.z != 0.0f) {
+         std::cout << "HERE Z!" << std::endl;
+               newPosition.z = oldPosition.z;
             }
          }
+         if (objTypeHit == GameObjectType::FINISH_OBJECT) {
+            GameManager::instance().gameOver_ = true;
+         }
       }
+
+      if (!objsHit.empty()) {
+         holder_->setPosition(newPosition);
+         updateBoundingBox();
+         //}
+      }
+      //}
    }
 
 

--- a/src/PlayerPhysicsComponent.cpp
+++ b/src/PlayerPhysicsComponent.cpp
@@ -13,7 +13,6 @@ void PlayerPhysicsComponent::initObjectPhysics() {
 }
 
 void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
-
    if (holder_->toggleMovement && holder_->velocity != 0.0f) {
       glm::vec3 oldPosition = holder_->getPosition();
       glm::vec3 newPosition = oldPosition + (holder_->velocity *

--- a/src/PlayerPhysicsComponent.cpp
+++ b/src/PlayerPhysicsComponent.cpp
@@ -13,7 +13,50 @@ void PlayerPhysicsComponent::initObjectPhysics() {
 }
 
 void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
-   if (holder_->toggleMovement) {
+
+   if (holder_->toggleMovement && holder_->velocity != 0.0f) {
+      glm::vec3 oldPosition = holder_->getPosition();
+      glm::vec3 newPosition = oldPosition + (holder_->velocity *
+         glm::normalize(holder_->direction) * deltaTime);
+      holder_->setPosition(newPosition);
+      updateBoundingBox();
+
+      // Check player collision against static objects
+      GameWorld& world = GameManager::instance().getGameWorld();
+      std::shared_ptr<GameObject> objHit = world.checkCollision(holder_);
+      if (objHit != nullptr) {
+         GameObjectType objTypeHit = objHit->type;
+
+         if (objTypeHit == GameObjectType::STATIC_OBJECT) {
+            BoundingBox* objHitBB = objHit->getBoundingBox();
+            glm::vec3 normalOfObjHit = objHitBB->calcReflNormal(getBoundingBox());
+
+            if (normalOfObjHit.x != 0.0f) {
+               newPosition.x = oldPosition.x;
+            }
+
+            if (normalOfObjHit.z != 0.0f) {
+               newPosition.z = oldPosition.z;
+            }
+
+            holder_->setPosition(newPosition);
+            updateBoundingBox();
+         }
+         if (objTypeHit == GameObjectType::FINISH_OBJECT) {
+            GameManager::instance().gameOver_ = true;
+         }
+      }
+   }
+
+
+
+
+
+
+
+
+
+   /*if (holder_->toggleMovement) {
       glm::vec3 newPosition = holder_->getPosition() + (holder_->velocity *
          glm::normalize(holder_->direction) * deltaTime);
       holder_->setPosition(newPosition);
@@ -37,5 +80,5 @@ void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
       if (objTypeHit == GameObjectType::FINISH_OBJECT) {
          GameManager::instance().gameOver_ = true;
       }
-   }
+   }*/
 }

--- a/src/PlayerPhysicsComponent.cpp
+++ b/src/PlayerPhysicsComponent.cpp
@@ -23,27 +23,31 @@ void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
 
       // Check player collision against static objects
       GameWorld& world = GameManager::instance().getGameWorld();
-      std::shared_ptr<GameObject> objHit = world.checkCollision(holder_);
-      if (objHit != nullptr) {
-         GameObjectType objTypeHit = objHit->type;
+      std::vector<std::shared_ptr<GameObject>> objsHit = world.checkCollision(holder_);
 
-         if (objTypeHit == GameObjectType::STATIC_OBJECT) {
-            BoundingBox* objHitBB = objHit->getBoundingBox();
-            glm::vec3 normalOfObjHit = objHitBB->calcReflNormal(getBoundingBox());
+      if (!objsHit.empty()) {
+         std::shared_ptr<GameObject> objHit = objsHit[0];
+         if (objHit != nullptr) {
+            GameObjectType objTypeHit = objHit->type;
 
-            if (normalOfObjHit.x != 0.0f) {
-               newPosition.x = oldPosition.x;
+            if (objTypeHit == GameObjectType::STATIC_OBJECT) {
+               BoundingBox* objHitBB = objHit->getBoundingBox();
+               glm::vec3 normalOfObjHit = objHitBB->calcReflNormal(getBoundingBox());
+
+               if (normalOfObjHit.x != 0.0f) {
+                  newPosition.x = oldPosition.x;
+               }
+
+               if (normalOfObjHit.z != 0.0f) {
+                  newPosition.z = oldPosition.z;
+               }
+
+               holder_->setPosition(newPosition);
+               updateBoundingBox();
             }
-
-            if (normalOfObjHit.z != 0.0f) {
-               newPosition.z = oldPosition.z;
+            if (objTypeHit == GameObjectType::FINISH_OBJECT) {
+               GameManager::instance().gameOver_ = true;
             }
-
-            holder_->setPosition(newPosition);
-            updateBoundingBox();
-         }
-         if (objTypeHit == GameObjectType::FINISH_OBJECT) {
-            GameManager::instance().gameOver_ = true;
          }
       }
    }

--- a/src/PlayerPhysicsComponent.cpp
+++ b/src/PlayerPhysicsComponent.cpp
@@ -25,9 +25,6 @@ void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
       GameWorld& world = GameManager::instance().getGameWorld();
       std::vector<std::shared_ptr<GameObject>> objsHit = world.checkCollision(holder_);
 
-      /*if (!objsHit.empty()) {
-         std::shared_ptr<GameObject> objHit = objsHit[0];
-         if (objHit != nullptr) {*/
       for (auto objHit : objsHit) {
          GameObjectType objTypeHit = objHit->type;
 
@@ -36,17 +33,14 @@ void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
             glm::vec3 normalOfObjHit = objHitBB->calcReflNormal(getBoundingBox());
 
             if (normalOfObjHit.x != 0.0f) {
-         std::cout << "HERE X!" << std::endl;
                newPosition.x = oldPosition.x;
             }
 
             if (normalOfObjHit.y != 0.0f) {
-         std::cout << "HERE Y!" << std::endl;
                newPosition.y = oldPosition.y;
             }
 
             if (normalOfObjHit.z != 0.0f) {
-         std::cout << "HERE Z!" << std::endl;
                newPosition.z = oldPosition.z;
             }
          }
@@ -58,42 +52,6 @@ void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
       if (!objsHit.empty()) {
          holder_->setPosition(newPosition);
          updateBoundingBox();
-         //}
       }
-      //}
    }
-
-
-
-
-
-
-
-
-
-   /*if (holder_->toggleMovement) {
-      glm::vec3 newPosition = holder_->getPosition() + (holder_->velocity *
-         glm::normalize(holder_->direction) * deltaTime);
-      holder_->setPosition(newPosition);
-      updateBoundingBox();
-   }
-
-   // Check player collision against static objects
-   GameWorld& world = GameManager::instance().getGameWorld();
-   std::shared_ptr<GameObject> objHit = world.checkCollision(holder_);
-   if (objHit != nullptr) {
-      GameObjectType objTypeHit = objHit->type;
-
-      if (objTypeHit == GameObjectType::STATIC_OBJECT) {
-         if (holder_->velocity != 0.0f) {
-            glm::vec3 newPosition = holder_->getPosition() - (holder_->velocity * 
-               glm::normalize(holder_->direction) * deltaTime);
-            holder_->setPosition(newPosition);
-            updateBoundingBox();
-         }
-      }
-      if (objTypeHit == GameObjectType::FINISH_OBJECT) {
-         GameManager::instance().gameOver_ = true;
-      }
-   }*/
 }

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -177,6 +177,7 @@ static void mouseCallback(GLFWwindow* window, int button, int action, int mods) 
 }
 
 static void cursorPositionCallback(GLFWwindow* window, double posX, double posY) {
+#ifdef ENABLE_MOUSE
 	WindowManager& windowManager = WindowManager::instance();
     GameManager& gameManager = GameManager::instance();
     Camera& camera = gameManager.getCamera();
@@ -195,6 +196,7 @@ static void cursorPositionCallback(GLFWwindow* window, double posX, double posY)
 
     camera.changeAlpha(deltaAlpha);
     camera.changeBeta(deltaBeta);
+#endif
 }
 
 static void resizeCallback(GLFWwindow* window, int width, int height) {


### PR DESCRIPTION
Hey all, this implements a first pass of the wall sliding we've needed for a while.  Not perfect as you can still get "sticky" once you're sliding on the wall occasionally, but it's a huge improvement from my testing.

BIG ISSUE though, that, hopefully, you all can help with.

You should see the "hack" comment in BoundingBox.cpp; for some reason the reflection logic was returning x-normal collisions as y-normal collisions.  This is really odd obviously (but does explain why the cookies were going through some hedges but not others, any hedges placed parallel to the x axis were fudged).  This is kind of hard to verbally explain, but if you try throwing cookies through the hedge behind the player at start you'll see what I'm talking about (without this PR that is!).

Anyway, been looking at this for a while and can't see it easily, hopefully, just missing something dumb from the existing reflection or BB logic you all can spot (as I didn't change anything there other than the hack).  Works as is right now but it's the literal definition of a hack :P