### PR TITLE
Fixes build issue on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ _Pvt_Extensions
 # Paket dependency manager
 .paket/paket.exe
 paket-files/
+
+# Local CMake files (windows)
+/CMakeFiles

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,11 @@
 #include "WallRenderComponent.h"
 #include "CookieActionComponent.h"
 
+#ifdef _WIN32
+#include <gl\gl.h>
+#pragma comment(lib, "opengl32.lib")
+#endif
+
 // Where the resources are loaded from
 std::string resourceDirectory = "../resources/";
 


### PR DESCRIPTION
Sorry for making this branch on the primary repo, working out the windows kinks :P

But adding the extra include/pragma on windows allows it to properly find OpenGL and build/run using our normal cmake build process, so should be good to go (I know both of you have been dying to do dev on your windows machines haha).