### PR TITLE
Fire Hydrant Rotations/Refactoring

### DIFF
--- a/src/FireHydrantPhysicsComponent.cpp
+++ b/src/FireHydrantPhysicsComponent.cpp
@@ -29,6 +29,12 @@ void FireHydrantPhysicsComponent::updatePhysics(float deltaTime) {
    } else {
       yVelocity = 0.0f;
       holder_->velocity = 0.0f;
+
+      // Set the position above ground plane.
+      // TODO (noj) we'll want to set the position relative to the object it lands on.
+      glm::vec3 newPos = holder_->getPosition();
+      newPos.y = 1.0f;
+      holder_->setPosition(newPos);
    }
 
    std::vector<std::shared_ptr<GameObject>> objsHit = world.checkCollision(holder_);
@@ -48,7 +54,6 @@ void FireHydrantPhysicsComponent::updatePhysics(float deltaTime) {
          // Initialize animation parameters.
          animated = true;
          animRotAxis = rotAxis;
-         animDuration = 0.0f;
       } else if (objTypeHit == GameObjectType::STATIC_OBJECT ||
                  objTypeHit == GameObjectType::DYNAMIC_OBJECT) {
          BoundingBox* objBB = objHit->getBoundingBox();
@@ -73,14 +78,6 @@ void FireHydrantPhysicsComponent::updateAnimation(float deltaTime) {
    if (holder_->velocity == 0.0f) {
       animated = false;
    } else {
-      if (animDuration != 0.0f) {
-         // Pop off the previous rotation.
-         holder_->popRotation();
-      }
-
-      animDuration += deltaTime * animSpeed;
-      /* TODO (noj) this isn't really safe if other things push on animations
-         make like a map who's key is the rotation axis. */
-      holder_->pushRotation(animDuration, animRotAxis);
+      holder_->addRotation(deltaTime * animSpeed, animRotAxis);
    }
 }

--- a/src/FireHydrantPhysicsComponent.cpp
+++ b/src/FireHydrantPhysicsComponent.cpp
@@ -44,6 +44,11 @@ void FireHydrantPhysicsComponent::updatePhysics(float deltaTime) {
 
          holder_->direction = reactDir;
          holder_->velocity = objHit->velocity * 2.0;
+
+         // Initialize animation parameters.
+         animated = true;
+         animRotAxis = rotAxis;
+         animDuration = 0.0f;
       } else if (objTypeHit == GameObjectType::STATIC_OBJECT ||
                  objTypeHit == GameObjectType::DYNAMIC_OBJECT) {
          BoundingBox* objBB = objHit->getBoundingBox();
@@ -57,5 +62,25 @@ void FireHydrantPhysicsComponent::updatePhysics(float deltaTime) {
          holder_->setPosition(newPosition);
          updateBoundingBox();
       }
+   }
+
+   if (animated) {
+      updateAnimation(deltaTime);
+   }
+}
+
+void FireHydrantPhysicsComponent::updateAnimation(float deltaTime) {
+   if (holder_->velocity == 0.0f) {
+      animated = false;
+   } else {
+      if (animDuration != 0.0f) {
+         // Pop off the previous rotation.
+         holder_->popRotation();
+      }
+
+      animDuration += deltaTime * animSpeed;
+      /* TODO (noj) this isn't really safe if other things push on animations
+         make like a map who's key is the rotation axis. */
+      holder_->pushRotation(animDuration, animRotAxis);
    }
 }

--- a/src/FireHydrantPhysicsComponent.cpp
+++ b/src/FireHydrantPhysicsComponent.cpp
@@ -61,6 +61,7 @@ void FireHydrantPhysicsComponent::updatePhysics(float deltaTime) {
 
          glm::vec3 normal = objBB->calcReflNormal(*thisBB);
          holder_->direction = glm::reflect(holder_->direction, normal);
+         animRotAxis = glm::cross(holder_->direction, glm::vec3(0, 1, 0));
 
          newPosition = oldPosition + (holder_->velocity * holder_->direction * deltaTime);
          newPosition += glm::vec3(0.0, yVelocity* deltaTime, 0.0);

--- a/src/FireHydrantPhysicsComponent.h
+++ b/src/FireHydrantPhysicsComponent.h
@@ -19,7 +19,7 @@ private:
    float gravity;
    float yVelocity;
 
-   /* Animation datat */
+   /* Animation data */
    bool animated;
    glm::vec3 animRotAxis;
    const float animSpeed = 5.0;

--- a/src/FireHydrantPhysicsComponent.h
+++ b/src/FireHydrantPhysicsComponent.h
@@ -22,7 +22,6 @@ private:
    /* Animation datat */
    bool animated;
    glm::vec3 animRotAxis;
-   float animDuration;
    const float animSpeed = 5.0;
 };
 

--- a/src/FireHydrantPhysicsComponent.h
+++ b/src/FireHydrantPhysicsComponent.h
@@ -13,9 +13,17 @@ public:
 
    void updatePhysics(float deltaTime);
 
+   void updateAnimation(float deltaTime);
+
 private:
    float gravity;
    float yVelocity;
+
+   /* Animation datat */
+   bool animated;
+   glm::vec3 animRotAxis;
+   float animDuration;
+   const float animSpeed = 5.0;
 };
 
 #endif

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -99,10 +99,6 @@ void GameObject::addRotation(float angle, const glm::vec3& axis) {
    transform.addRotation(angle, axis);
 }
 
-void GameObject::popRotation() {
-   transform.popRotation();
-}
-
 void GameObject::changeMaterial(std::shared_ptr<Material> newMaterial) {
 	if (newMaterial != render_->getMaterial()) {
 		render_->setMaterial(newMaterial);

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -95,8 +95,8 @@ void GameObject::setYAxisRotation(float angle) {
 	transform.setRotate(angle, yAxis);
 }
 
-void GameObject::pushRotation(float angle, const glm::vec3& axis) {
-   transform.pushRotation(angle, axis);
+void GameObject::addRotation(float angle, const glm::vec3& axis) {
+   transform.addRotation(angle, axis);
 }
 
 void GameObject::popRotation() {

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -95,6 +95,13 @@ void GameObject::setYAxisRotation(float angle) {
 	transform.setRotate(angle, yAxis);
 }
 
+void GameObject::pushRotation(float angle, const glm::vec3& axis) {
+   transform.pushRotation(angle, axis);
+}
+
+void GameObject::popRotation() {
+   transform.popRotation();
+}
 
 void GameObject::changeMaterial(std::shared_ptr<Material> newMaterial) {
 	if (newMaterial != render_->getMaterial()) {

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -69,8 +69,6 @@ public:
 
     void addRotation(float angle, const glm::vec3& axis);
 
-    void popRotation();
-
     void calculateAndSetInitialRotation();
 
     void changeMaterial(std::shared_ptr<Material> newMaterial);

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -67,7 +67,7 @@ public:
 
     void setYAxisRotation(float angle);
 
-    void pushRotation(float angle, const glm::vec3& axis);
+    void addRotation(float angle, const glm::vec3& axis);
 
     void popRotation();
 

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -67,6 +67,10 @@ public:
 
     void setYAxisRotation(float angle);
 
+    void pushRotation(float angle, const glm::vec3& axis);
+
+    void popRotation();
+
     void calculateAndSetInitialRotation();
 
     void changeMaterial(std::shared_ptr<Material> newMaterial);

--- a/src/MatrixStack.cpp
+++ b/src/MatrixStack.cpp
@@ -59,6 +59,11 @@ void MatrixStack::rotate(float angle, const glm::vec3 &axis)
 	top *= r;
 }
 
+void MatrixStack::rotateMat4(glm::mat4 &rotMat) {
+   glm::mat4 &top = mstack->top();
+   top *= rotMat;
+}
+
 void MatrixStack::multMatrix(const glm::mat4 &matrix)
 {
    glm::mat4 &top = mstack->top();

--- a/src/MatrixStack.h
+++ b/src/MatrixStack.h
@@ -41,6 +41,8 @@ public:
    void scale(float size);
    // Right multiplies the top matrix by a rotation matrix (angle in deg)
    void rotate(float angle, const glm::vec3 &axis);
+   // Same as rotate but takes the matrix already
+   void rotateMat4(glm::mat4 &rotMat);
 
    // Gets the top matrix
    const glm::mat4 &topMatrix();

--- a/src/MatrixTransform.cpp
+++ b/src/MatrixTransform.cpp
@@ -7,9 +7,8 @@
 MatrixTransform::MatrixTransform() :
    transform_(glm::mat4(1.0)),
    translate_(glm::mat4(1.0)),
-   scale_(glm::mat4(1.0)) {
-
-   rotate_.push_front(glm::mat4(1.0));
+   scale_(glm::mat4(1.0)),
+   rotate_(glm::mat4(1.)) {
 }
 
 MatrixTransform::~MatrixTransform() {
@@ -21,13 +20,7 @@ glm::mat4& MatrixTransform::getTransform() {
 }
 
 glm::mat4 MatrixTransform::getRotate() {
-   glm::mat4 rotation(glm::mat4(1.0));
-
-   for (glm::mat4 rot : rotate_) {
-      rotation *= rot;
-   }
-
-   return rotation;
+   return rotate_;
 }
 
 void MatrixTransform::setTranslation(glm::vec3& offset) {
@@ -43,30 +36,21 @@ void MatrixTransform::setScale(glm::vec3& scaleV) {
 }
 
 void MatrixTransform::setRotate(float angle, const glm::vec3& axis) {
-   rotate_.clear();
-   rotate_.push_front(glm::rotate(glm::mat4(1.0), angle, axis));
+   rotate_ = glm::rotate(glm::mat4(1.0), angle, axis);
 
    updateTransform();
 }
 
-void MatrixTransform::pushRotation(float angle, const glm::vec3& axis) {
-   rotate_.push_front(glm::rotate(glm::mat4(1.0), angle, axis));
+void MatrixTransform::addRotation(float angle, const glm::vec3& axis) {
+   rotate_ *= glm::rotate(glm::mat4(1.0), angle, axis);
 
    updateTransform();
 }
 
 void MatrixTransform::popRotation() {
-   rotate_.pop_front();
-
    updateTransform();
 }
 
 void MatrixTransform::updateTransform() {
-   transform_ = translate_;
-
-   for (glm::mat4 rotation : rotate_) {
-      transform_ *= rotation;
-   }
-
-   transform_ *= scale_;
+   transform_ = translate_ * rotate_ * scale_;
 }

--- a/src/MatrixTransform.cpp
+++ b/src/MatrixTransform.cpp
@@ -47,10 +47,6 @@ void MatrixTransform::addRotation(float angle, const glm::vec3& axis) {
    updateTransform();
 }
 
-void MatrixTransform::popRotation() {
-   updateTransform();
-}
-
 void MatrixTransform::updateTransform() {
    transform_ = translate_ * rotate_ * scale_;
 }

--- a/src/MatrixTransform.cpp
+++ b/src/MatrixTransform.cpp
@@ -8,7 +8,7 @@ MatrixTransform::MatrixTransform() :
    transform_(glm::mat4(1.0)),
    translate_(glm::mat4(1.0)),
    scale_(glm::mat4(1.0)),
-   rotate_(glm::mat4(1.)) {
+   rotate_(glm::mat4(1.0)) {
 }
 
 MatrixTransform::~MatrixTransform() {

--- a/src/MatrixTransform.cpp
+++ b/src/MatrixTransform.cpp
@@ -1,0 +1,72 @@
+#include "MatrixTransform.h"
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <iostream>
+
+MatrixTransform::MatrixTransform() :
+   transform_(glm::mat4(1.0)),
+   translate_(glm::mat4(1.0)),
+   scale_(glm::mat4(1.0)) {
+
+   rotate_.push_front(glm::mat4(1.0));
+}
+
+MatrixTransform::~MatrixTransform() {
+
+}
+
+glm::mat4& MatrixTransform::getTransform() {
+   return transform_;
+}
+
+glm::mat4 MatrixTransform::getRotate() {
+   glm::mat4 rotation(glm::mat4(1.0));
+
+   for (glm::mat4 rot : rotate_) {
+      rotation *= rot;
+   }
+
+   return rotation;
+}
+
+void MatrixTransform::setTranslation(glm::vec3& offset) {
+   translate_ = glm::translate(glm::mat4(1.0), offset);
+
+   updateTransform();
+}
+
+void MatrixTransform::setScale(glm::vec3& scaleV) {
+   scale_ = glm::scale(glm::mat4(1.0), scaleV);
+
+   updateTransform();
+}
+
+void MatrixTransform::setRotate(float angle, const glm::vec3& axis) {
+   rotate_.clear();
+   rotate_.push_front(glm::rotate(glm::mat4(1.0), angle, axis));
+
+   updateTransform();
+}
+
+void MatrixTransform::pushRotation(float angle, const glm::vec3& axis) {
+   rotate_.push_front(glm::rotate(glm::mat4(1.0), angle, axis));
+
+   updateTransform();
+}
+
+void MatrixTransform::popRotation() {
+   rotate_.pop_front();
+
+   updateTransform();
+}
+
+void MatrixTransform::updateTransform() {
+   transform_ = translate_;
+
+   for (glm::mat4 rotation : rotate_) {
+      transform_ *= rotation;
+   }
+
+   transform_ *= scale_;
+}

--- a/src/MatrixTransform.h
+++ b/src/MatrixTransform.h
@@ -25,8 +25,6 @@ public:
    /* Adds a rotation matrix to the rotate_ list, this list is used as a stack
       but needs to be iterated through in updateTransform() */
    void addRotation(float angle, const glm::vec3& axis);
-
-   void popRotation();
 private:
 
 	glm::mat4 transform_;

--- a/src/MatrixTransform.h
+++ b/src/MatrixTransform.h
@@ -1,55 +1,42 @@
 #ifndef MATRIX_TRANSFORM_H
 #define MATRIX_TRANSFORM_H
 
-#define _USE_MATH_DEFINES
-#include <math.h>
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <list>
 
-// TODO(rgarmsen2295): Separate into .cpp file or make inline
 class MatrixTransform {
 public:
 
-	MatrixTransform() 
-		: transform_(glm::mat4(1.0)),
-		translate_(glm::mat4(1.0)),
-		scale_(glm::mat4(1.0)),
-		rotate_(glm::mat4(1.0)) {}
+	MatrixTransform(); 
 
-	~MatrixTransform() {}
+	~MatrixTransform();
 
-	glm::mat4& getTransform() { return transform_; }
+	glm::mat4& getTransform();
 
-	void setTranslation(glm::vec3& offset) {
-		translate_ = glm::translate(glm::mat4(1.0), offset);
+   glm::mat4 getRotate();
 
-		updateTransform();
-	}
+	void setTranslation(glm::vec3& offset);
 
-	void setScale(glm::vec3& scaleV) {
-		scale_ = glm::scale(glm::mat4(1.0), scaleV);
+	void setScale(glm::vec3& scaleV);
 
-		updateTransform();
-	}
+   /* Empties the rotation list and pushes an initial rotation. */
+	void setRotate(float angle, const glm::vec3& axis);
 
-	// TODO(rgarmsen2295): Add seperate functions and member variables to allow for x, y, AND z rotation at the same time
-	void setRotate(float angle, const glm::vec3& axis)
-	{
-		rotate_ = glm::rotate(glm::mat4(1.0), angle, axis);
+   /* Adds a rotation matrix to the rotate_ list, this list is used as a stack
+      but needs to be iterated through in updateTransform() */
+   void pushRotation(float angle, const glm::vec3& axis);
 
-		updateTransform();
-	}
-
+   void popRotation();
 private:
 
 	glm::mat4 transform_;
 
 	glm::mat4 translate_;
 	glm::mat4 scale_;
-	glm::mat4 rotate_;
+	std::list<glm::mat4> rotate_;
 
-	// TODO(rgarmsen): Add options on how to do the transform update (e.g. different orders)
-	void updateTransform() {
-		transform_ = translate_ * rotate_ * scale_;
-	}
+	void updateTransform();
 };
 
 #endif

--- a/src/MatrixTransform.h
+++ b/src/MatrixTransform.h
@@ -3,7 +3,6 @@
 
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtc/matrix_transform.hpp>
-#include <list>
 
 class MatrixTransform {
 public:
@@ -25,7 +24,7 @@ public:
 
    /* Adds a rotation matrix to the rotate_ list, this list is used as a stack
       but needs to be iterated through in updateTransform() */
-   void pushRotation(float angle, const glm::vec3& axis);
+   void addRotation(float angle, const glm::vec3& axis);
 
    void popRotation();
 private:
@@ -34,7 +33,7 @@ private:
 
 	glm::mat4 translate_;
 	glm::mat4 scale_;
-	std::list<glm::mat4> rotate_;
+	glm::mat4 rotate_;
 
 	void updateTransform();
 };

--- a/src/MatrixTransform.h
+++ b/src/MatrixTransform.h
@@ -19,11 +19,8 @@ public:
 
 	void setScale(glm::vec3& scaleV);
 
-   /* Empties the rotation list and pushes an initial rotation. */
 	void setRotate(float angle, const glm::vec3& axis);
 
-   /* Adds a rotation matrix to the rotate_ list, this list is used as a stack
-      but needs to be iterated through in updateTransform() */
    void addRotation(float angle, const glm::vec3& axis);
 private:
 

--- a/src/ShaderManager.cpp
+++ b/src/ShaderManager.cpp
@@ -178,7 +178,9 @@ void ShaderManager::renderObject(std::shared_ptr<GameObject> objToRender, const 
 
 		M->translate(objToRender->getPosition());
 		M->scale(objToRender->getScale());
-		M->rotate(objToRender->getYAxisRotation(), glm::vec3(0.0f, 1.0f, 0.0f));
+
+      glm::mat4 rotation = objToRender->transform.getRotate();
+		M->rotateMat4(rotation);
 
 		glUniformMatrix4fv(shaderProgram->getUniform("M"), 1, GL_FALSE, glm::value_ptr(M->topMatrix()));
 


### PR DESCRIPTION
Updated the `MatrixTransform` code and now allows the fire hydrant to spin on impact. Also I noticed `MatrixTransform` is our container for transformations but in `ShaderManager` we aren't using them really. I ended up using the objects transform variable for rotations but we might want to do this for everything instead of having like `getScale()` in `GameObject` and what not. In short, we should rely on the `transform` variable to handle all that information.