### PR TITLE
Shadowmaps

### DIFF
--- a/resources/phong_frag.glsl
+++ b/resources/phong_frag.glsl
@@ -1,4 +1,5 @@
 #version 330 core
+uniform sampler2D shadowMapTex;
 
 #define MAX_POINT_LIGHTS 10
 #define MAX_DIRECTION_LIGHTS 10
@@ -36,6 +37,8 @@ uniform mat4 V;
 
 in vec3 positionInCamSpace;
 in vec3 normalInWorldSpace;
+in vec3 positionInLightSpace;
+
 
 out vec4 color;
 
@@ -97,6 +100,24 @@ void main() {
 	// Calculate ambient color
 	vec3 ambient = MatAmb;
 
+	//sm
+	float shadeFactor = 1.0;
+
+	vec3 shifted = (positionInLightSpace + 1.0) / 2.0;
+
+	if(shifted.x > 1.0 || shifted.x < 0.0 || shifted.y > 1.0 || shifted.y < 0.0 ) {
+	    shadeFactor = 0.3;
+	} else {
+        float curDepth = shifted.z;
+        float smValue = texture(shadowMapTex, shifted.xy).r;
+
+        if((smValue + 0.001) < curDepth) {
+               shadeFactor = 0.5;
+        }
+    }
+
+
 	// Calculate the total color
-	color = vec4(directionalLightColor + ambient, 1.0);
+	color = shadeFactor * vec4(directionalLightColor + ambient, 1.0);
+	//color = vec4(vec3(smValue), 1.0);
 }

--- a/resources/phong_frag.glsl
+++ b/resources/phong_frag.glsl
@@ -105,6 +105,32 @@ void main() {
 
 	vec3 shifted = (positionInLightSpace + 1.0) / 2.0;
 
+	float smTexOffset = 1.0/16384.0;
+	float samples = 0.0;
+	float shadedFrags = 0.0;
+
+	for (float i = -3.0; i<=3.0; i++) {
+		for (float j = -3.0; j<=3.0; j++) {
+		        vec3 shiftedOffsetted = vec3(shifted.x + i * smTexOffset, shifted.y + j * smTexOffset, shifted.z);
+    	    	if(shiftedOffsetted.x > 1.0 || shiftedOffsetted.x < 0.0 || shiftedOffsetted.y > 1.0 || shiftedOffsetted.y < 0.0 ) {
+            	    //shadeFactor = 0.3;
+            	} else {
+                    float curDepth = shifted.z;
+                    float smValue = texture(shadowMapTex, shiftedOffsetted.xy).r;
+
+                    samples++;
+                    if((smValue + 0.001) < curDepth) {
+                           //shadeFactor = 0.5;
+                           shadedFrags++;
+                    }
+                }
+    	}
+	}
+
+	float PCFfac = shadedFrags / samples;
+	shadeFactor = PCFfac * 0.5 + (1.0 -PCFfac) * 1.0;
+
+    /*
 	if(shifted.x > 1.0 || shifted.x < 0.0 || shifted.y > 1.0 || shifted.y < 0.0 ) {
 	    shadeFactor = 0.3;
 	} else {
@@ -115,7 +141,7 @@ void main() {
                shadeFactor = 0.5;
         }
     }
-
+    */
 
 	// Calculate the total color
 	color = shadeFactor * vec4(directionalLightColor + ambient, 1.0);

--- a/resources/phong_vert.glsl
+++ b/resources/phong_vert.glsl
@@ -6,17 +6,22 @@ layout(location = 1) in vec3 vertNor;
 uniform mat4 P;
 uniform mat4 M;
 uniform mat4 V;
+uniform mat4 lightV;
+uniform mat4 lightP;
 uniform mat4 tiM;
 
 // Push the position in camera space and normal in world space
 // to the fragment shader
 out vec3 positionInCamSpace;
 out vec3 normalInWorldSpace;
+out vec3 positionInLightSpace;
 
 void main() {
 
 	// Set the position of the vertex in homogeneous space
 	gl_Position = P * V * M * vertPos;
+
+	positionInLightSpace = (lightP * lightV * M * vertPos).xyz;
 
 	// Calculate the position of the vertex in camera/view space
 	positionInCamSpace = (V * M * vertPos).xyz;

--- a/resources/shadowPass_frag.glsl
+++ b/resources/shadowPass_frag.glsl
@@ -1,0 +1,10 @@
+#version 330 core
+
+/* do nothing - pass through as depth written to FBO */
+//out vec4 color;
+
+void main() {
+    //color = vec4(0, gl_FragCoord.z, gl_FragCoord.z, 1.0);
+}
+
+

--- a/resources/shadowPass_frag.glsl
+++ b/resources/shadowPass_frag.glsl
@@ -1,10 +1,8 @@
 #version 330 core
 
 /* do nothing - pass through as depth written to FBO */
-//out vec4 color;
 
 void main() {
-    //color = vec4(0, gl_FragCoord.z, gl_FragCoord.z, 1.0);
 }
 
 

--- a/resources/shadowPass_vert.glsl
+++ b/resources/shadowPass_vert.glsl
@@ -1,0 +1,14 @@
+#version  330 core
+
+layout(location = 0) in vec3 vertPos;
+
+uniform mat4 lightP;
+uniform mat4 lightV;
+uniform mat4 M;
+
+void main() {
+
+  /* transform into light space */
+  gl_Position = lightP * lightV * M * vec4(vertPos.xyz, 1.0);
+
+}

--- a/src/AimRenderComponent.cpp
+++ b/src/AimRenderComponent.cpp
@@ -1,0 +1,22 @@
+#include "AimRenderComponent.h"
+#include "GameObject.h"
+#include "ShaderManager.h"
+
+AimRenderComponent::AimRenderComponent(std::shared_ptr<Shape> shape, const std::string& shaderName, std::shared_ptr<Material> material)
+        : RenderComponent(shape, shaderName, material) {
+}
+
+AimRenderComponent::~AimRenderComponent() {
+
+}
+
+void AimRenderComponent::draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V) {
+    ShaderManager& shaderManager = ShaderManager::instance();
+    shaderManager.renderObject(holder_, shaderName_, shape_, material_, P, V, M);
+}
+
+void AimRenderComponent::renderShadow(std::shared_ptr <MatrixStack> M) {
+    // don't do anything, the aim shouldn't create a shadow
+}
+
+

--- a/src/AimRenderComponent.h
+++ b/src/AimRenderComponent.h
@@ -1,0 +1,20 @@
+#ifndef AIM_RENDER_COMPONENT_H
+#define AIM_RENDER_COMPONENT_H
+
+#include "RenderComponent.h"
+
+class AimRenderComponent : public RenderComponent {
+public:
+    AimRenderComponent(std::shared_ptr<Shape> shape, const std::string& shaderName, std::shared_ptr<Material> material);
+
+    ~AimRenderComponent();
+
+    void draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V);
+
+    void renderShadow(std::shared_ptr<MatrixStack> M);
+
+private:
+
+};
+
+#endif

--- a/src/BunnyRenderComponent.cpp
+++ b/src/BunnyRenderComponent.cpp
@@ -14,3 +14,8 @@ void BunnyRenderComponent::draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<
 	ShaderManager& shaderManager = ShaderManager::instance();
 	shaderManager.renderObject(holder_, shaderName_, shape_, material_, P, V, M);
 }
+
+void BunnyRenderComponent::renderShadow(std::shared_ptr <MatrixStack> M) {
+	ShaderManager& shaderManager = ShaderManager::instance();
+	shaderManager.renderShadowPass(holder_, shape_, M);
+}

--- a/src/BunnyRenderComponent.h
+++ b/src/BunnyRenderComponent.h
@@ -11,6 +11,8 @@ public:
 
 	void draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V);
 
+	void renderShadow(std::shared_ptr<MatrixStack> M);
+
 private:
 
 };

--- a/src/CookieActionComponent.cpp
+++ b/src/CookieActionComponent.cpp
@@ -97,8 +97,9 @@ void CookieActionComponent::initActionComponent() {
     GameManager::instance().getGameWorld().addDynamicGameObject(gameObj);
     GameManager::instance().getGameWorld().addDynamicGameObject(gameObj1);
     GameManager::instance().getGameWorld().addDynamicGameObject(gameObj2);
-    GameManager::instance().getGameWorld().addDynamicGameObject(gameObj3);
     GameManager::instance().getGameWorld().addDynamicGameObject(gameObj4);
+    GameManager::instance().getGameWorld().addDynamicGameObject(gameObj3);
+
 
 }
 

--- a/src/CookieActionComponent.cpp
+++ b/src/CookieActionComponent.cpp
@@ -3,6 +3,7 @@
 #include "ShaderManager.h"
 #include "ShapeManager.h"
 #include "MaterialManager.h"
+#include "AimRenderComponent.h"
 #include <glm/gtx/rotate_vector.hpp>
 
 /*
@@ -16,15 +17,15 @@ CookieActionComponent::CookieActionComponent() {
     ShapeManager& shapeManager = ShapeManager::instance();
     MaterialManager& materialManager = MaterialManager::instance();
 
-    BunnyRenderComponent* bunnyRenderComp = new BunnyRenderComponent(
+    AimRenderComponent* aimRenderComponent = new AimRenderComponent(
       shapeManager.getShape("Sphere"), "Phong", materialManager.getMaterial("Brass"));
-    BunnyRenderComponent* bunnyRenderComp1 = new BunnyRenderComponent(
+    AimRenderComponent* aimRenderComponent1 = new AimRenderComponent(
       shapeManager.getShape("Sphere"), "Phong", materialManager.getMaterial("Brass"));
-    BunnyRenderComponent* bunnyRenderComp2 = new BunnyRenderComponent(
+    AimRenderComponent* aimRenderComponent2 = new AimRenderComponent(
       shapeManager.getShape("Sphere"), "Phong", materialManager.getMaterial("Brass"));
-    BunnyRenderComponent* bunnyRenderComp3 = new BunnyRenderComponent(
+    AimRenderComponent* aimRenderComponent3 = new AimRenderComponent(
       shapeManager.getShape("Sphere"), "Phong", materialManager.getMaterial("Brass"));
-    BunnyRenderComponent* bunnyRenderComp4 = new BunnyRenderComponent(
+    AimRenderComponent* aimRenderComponent4 = new AimRenderComponent(
       shapeManager.getShape("Sphere"), "Phong", materialManager.getMaterial("Brass"));
 
 
@@ -37,7 +38,7 @@ CookieActionComponent::CookieActionComponent() {
             glm::vec3(0.1),
             nullptr,
             nullptr,
-            bunnyRenderComp,
+            aimRenderComponent,
             nullptr);
     gameObj->initComponents();
 
@@ -49,7 +50,7 @@ CookieActionComponent::CookieActionComponent() {
             glm::vec3(0.1),
             nullptr,
             nullptr,
-            bunnyRenderComp1,
+            aimRenderComponent1,
             nullptr);
     gameObj1->initComponents();
 
@@ -61,7 +62,7 @@ CookieActionComponent::CookieActionComponent() {
             glm::vec3(0.1),
             nullptr,
             nullptr,
-            bunnyRenderComp2,
+            aimRenderComponent2,
             nullptr);
     gameObj2->initComponents();
 
@@ -73,7 +74,7 @@ CookieActionComponent::CookieActionComponent() {
             glm::vec3(0.1),
             nullptr,
             nullptr,
-            bunnyRenderComp3,
+            aimRenderComponent3,
             nullptr);
     gameObj3->initComponents();
 
@@ -85,7 +86,7 @@ CookieActionComponent::CookieActionComponent() {
             glm::vec3(0.1),
             nullptr,
             nullptr,
-            bunnyRenderComp4,
+            aimRenderComponent4,
             nullptr);
     gameObj4->initComponents();
 }
@@ -97,8 +98,8 @@ void CookieActionComponent::initActionComponent() {
     GameManager::instance().getGameWorld().addDynamicGameObject(gameObj);
     GameManager::instance().getGameWorld().addDynamicGameObject(gameObj1);
     GameManager::instance().getGameWorld().addDynamicGameObject(gameObj2);
-    GameManager::instance().getGameWorld().addDynamicGameObject(gameObj4);
     GameManager::instance().getGameWorld().addDynamicGameObject(gameObj3);
+    GameManager::instance().getGameWorld().addDynamicGameObject(gameObj4);
 
 
 }

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -63,6 +63,14 @@ void GameManager::increaseTime(float deltaTime) {
     time_ += deltaTime;
 }
 
+void GameManager::setShadowMap(ShadowMap *shadowMap) {
+    shadowMap_ = shadowMap;
+}
+
+ShadowMap* GameManager::getShadowMap() {
+    return shadowMap_;
+}
+
 void GameManager::showScore() {
     if(gameOver_) {
         if(time_ <= 0.0) {

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -4,6 +4,7 @@
 #include "Camera.h"
 #include "GameWorld.h"
 #include "ViewFrustum.h"
+#include "ShadowMap.h"
 
 // Singleton class that handles any global game state not easily categorized into other areas
 class GameManager {
@@ -59,6 +60,15 @@ public:
     //Increases the remaining time
     void increaseTime(float deltaTime);
 
+	// set a Shadow Map Object
+	void setShadowMap(ShadowMap* shadowMap);
+
+	// Returns the Shadow Map object
+	ShadowMap* getShadowMap();
+
+    static constexpr float playerFarPlane = 100.0;
+    static constexpr float playerNearPlane = 0.01;
+
 private:
 
 	GameManager() {}
@@ -71,9 +81,13 @@ private:
 
    ViewFrustum* currentViewFrustum_;
 
+	ShadowMap* shadowMap_;
+
 	float score_ = 0.0;
 
     float time_;
+
+
 };
 
 #endif

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -66,8 +66,9 @@ public:
 	// Returns the Shadow Map object
 	ShadowMap* getShadowMap();
 
-    static constexpr float playerFarPlane = 300.0;
-    static constexpr float playerNearPlane = 0.01;
+    static constexpr float cullFarPlane = 100.0;
+    static constexpr float camFarPlane = 300.0;
+    static constexpr float nearPlane = 0.01;
 
 private:
 

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -66,7 +66,7 @@ public:
 	// Returns the Shadow Map object
 	ShadowMap* getShadowMap();
 
-    static constexpr float playerFarPlane = 100.0;
+    static constexpr float playerFarPlane = 300.0;
     static constexpr float playerNearPlane = 0.01;
 
 private:

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -118,6 +118,12 @@ void GameObject::draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStac
 	}
 }
 
+void GameObject::renderToShadowMap(std::shared_ptr <MatrixStack> M) {
+	if (render_ != NULL) {
+		render_->renderShadow(M);
+	}
+}
+
 void GameObject::performAction(double deltaTime, double totalTime) {
     if (action_ != NULL) {
         action_->checkAndPerformAction(deltaTime, totalTime);

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -79,6 +79,9 @@ public:
     // Performs any render/draw updates necessary for the object
     void draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V);
 
+	// Renders the Object to the shadow map
+	void renderToShadowMap(std::shared_ptr<MatrixStack> M);
+
     // Perform the any actions that are bound to the object, if any and if applicable at that moment
     void performAction(double deltaTime, double totalTime);
 

--- a/src/GameWorld.cpp
+++ b/src/GameWorld.cpp
@@ -137,13 +137,16 @@ void GameWorld::drawGameObjects() {
 	std::shared_ptr<MatrixStack> P = std::make_shared<MatrixStack>();
 	std::shared_ptr<MatrixStack> M = std::make_shared<MatrixStack>();
 	std::shared_ptr<MatrixStack> V = std::make_shared<MatrixStack>();
+    //create another projection, identical but with closer far plane for VFC
+    std::shared_ptr<MatrixStack> cullP = std::make_shared<MatrixStack>();
 
 	// Apply perspective projection
 	P->pushMatrix();
+    cullP->pushMatrix();
 	//TODO(nurgan) check for better way of not clipping skybox instead of increasing far plane
 	//P->perspective(45.0f, windowManager.getAspectRatio(), 0.01f, 300.0f);
-    P->perspective(45.0f, windowManager.getAspectRatio(), GameManager::playerNearPlane, GameManager::playerFarPlane);
-
+    P->perspective(45.0f, windowManager.getAspectRatio(), GameManager::nearPlane, GameManager::camFarPlane);
+    cullP->perspective(45.0f, windowManager.getAspectRatio(), GameManager::nearPlane, GameManager::cullFarPlane);
 
     // Set up view Matrix
 	V->pushMatrix();
@@ -151,7 +154,7 @@ void GameWorld::drawGameObjects() {
 	V->lookAt(camera.getEye(), camera.getTarget(), camera.getUp());
 
    // Calculate view frustum planes
-   viewFrustum.extractPlanes(P->topMatrix(), V->topMatrix());
+   viewFrustum.extractPlanes(cullP->topMatrix(), V->topMatrix());
 
 	// Draw non-static objects
 	for (std::shared_ptr<GameObject> obj : dynamicGameObjects_) {

--- a/src/GameWorld.cpp
+++ b/src/GameWorld.cpp
@@ -124,10 +124,14 @@ void GameWorld::updateGameObjects(double deltaTime, double totalTime) {
 
 void GameWorld::drawGameObjects() {
 	GameManager& gameManager = GameManager::instance();
+
+    gameManager.getShadowMap()->bindForDraw();
+
 	Camera& camera = gameManager.getCamera();
    ViewFrustum& viewFrustum = gameManager.getViewFrustum();
 
 	WindowManager& windowManager = WindowManager::instance();
+
 	
 	// Create the matrix stacks
 	std::shared_ptr<MatrixStack> P = std::make_shared<MatrixStack>();
@@ -137,9 +141,11 @@ void GameWorld::drawGameObjects() {
 	// Apply perspective projection
 	P->pushMatrix();
 	//TODO(nurgan) check for better way of not clipping skybox instead of increasing far plane
-	P->perspective(45.0f, windowManager.getAspectRatio(), 0.01f, 300.0f);
+	//P->perspective(45.0f, windowManager.getAspectRatio(), 0.01f, 300.0f);
+    P->perspective(45.0f, windowManager.getAspectRatio(), GameManager::playerNearPlane, GameManager::playerFarPlane);
 
-	// Set up view Matrix
+
+    // Set up view Matrix
 	V->pushMatrix();
 	V->loadIdentity();
 	V->lookAt(camera.getEye(), camera.getTarget(), camera.getUp());
@@ -165,6 +171,23 @@ void GameWorld::drawGameObjects() {
    #ifdef DEBUG
    drawVFCViewport();
    #endif
+}
+
+void GameWorld::renderShadowMap() {
+
+    GameManager::instance().getShadowMap()->bindForShadowPass();
+
+    std::shared_ptr<MatrixStack> M = std::make_shared<MatrixStack>();
+
+    // Draw non-static objects
+    for (std::shared_ptr<GameObject> obj : dynamicGameObjects_) {
+            obj->renderToShadowMap(M);
+    }
+
+    // Draw static objects
+    for (std::shared_ptr<GameObject> obj : staticGameObjects_) {
+            obj->renderToShadowMap(M);
+    }
 }
 
 // For debugging view frustum culling. This is mostly magic.

--- a/src/GameWorld.h
+++ b/src/GameWorld.h
@@ -83,6 +83,9 @@ public:
 	// Calls the draw function on all GameObjects in the world
 	void drawGameObjects();
 
+	// Renders all GameObjects to the shadow map
+	void renderShadowMap();
+
    // Draws a small view port to see view frustum culling
    void drawVFCViewport();
 

--- a/src/LevelLoader.cpp
+++ b/src/LevelLoader.cpp
@@ -96,6 +96,11 @@ int LevelLoader::parseShaders(json shaders) {
             return 1;
          }
       }
+      // load shadow pass shader
+      if (shaderManager.createIsomorphicShader(resourceManager, ShaderManager::shadowPassShaderName,
+                                               ShaderManager::shadowPassShaderName) == 0) {
+         return 1;
+      }
    }
 
    return 0;

--- a/src/PlayerRenderComponent.cpp
+++ b/src/PlayerRenderComponent.cpp
@@ -16,3 +16,8 @@ void PlayerRenderComponent::draw(std::shared_ptr<MatrixStack> P,
 
 	shaderManager.renderObject(holder_, shaderName_, shape_, material_, P, V, M);
 }
+
+void PlayerRenderComponent::renderShadow(std::shared_ptr <MatrixStack> M) {
+    ShaderManager& shaderManager = ShaderManager::instance();
+    shaderManager.renderShadowPass(holder_, shape_, M);
+}

--- a/src/PlayerRenderComponent.h
+++ b/src/PlayerRenderComponent.h
@@ -14,6 +14,8 @@ public:
 	void draw(std::shared_ptr<MatrixStack> P,
       std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V);
 
+	void renderShadow(std::shared_ptr<MatrixStack> M);
+
 private:
 
 };

--- a/src/Program.cpp
+++ b/src/Program.cpp
@@ -72,6 +72,10 @@ void Program::addDefaultAttributesAndUniforms() {
 	addUniform("V");
 	addUniform("P");
 
+	// Add light View and Projection
+	addUniform("lightV");
+	addUniform("lightP");
+
 	// Add transpose inverse M, so no per vertex calculation
 	addUniform("tiM");
 
@@ -85,6 +89,8 @@ void Program::addDefaultAttributesAndUniforms() {
 
 	//TODO(nurgan) remove from default attributs
 	addUniform("cubemap");
+
+	addUniform("shadowMapTex");
 
 	// Adds material uniforms
 	addUniform("MatAmb");

--- a/src/Program.cpp
+++ b/src/Program.cpp
@@ -76,6 +76,9 @@ void Program::addDefaultAttributesAndUniforms() {
 	addUniform("lightV");
 	addUniform("lightP");
 
+	// Add shadow map size
+	addUniform("shadowMapSize");
+
 	// Add transpose inverse M, so no per vertex calculation
 	addUniform("tiM");
 

--- a/src/RenderComponent.h
+++ b/src/RenderComponent.h
@@ -33,6 +33,9 @@ public:
 	// Draws the object using the passed Perspective (P), Model (M), and View (V) matrices
 	virtual void draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V) = 0;
 
+    // Renders the depht of the object to the shadow map
+    virtual void renderShadow(std::shared_ptr<MatrixStack> M) = 0;
+
 	inline void changeShader(const std::string& newShaderName) { shaderName_ = newShaderName; }
 
 protected:

--- a/src/ShaderManager.cpp
+++ b/src/ShaderManager.cpp
@@ -173,14 +173,13 @@ void ShaderManager::renderObject(std::shared_ptr<GameObject> objToRender, const 
 		glUniform1f(shaderProgram->getUniform("MatShiny"), material->shininess);
 
 
-
+        // Calculate and bind light transorms and shadow Map
         glm::mat4 lightP = calculateLightProjection(directionalLights.at(0));
-
-        //TODO(nurgan) check +/- if SM not working
         glm::mat4 lightV = calculateLightView(directionalLights.at(0));
 
         glUniformMatrix4fv(shaderProgram->getUniform("lightP"), 1, GL_FALSE, glm::value_ptr(lightP));
         glUniformMatrix4fv(shaderProgram->getUniform("lightV"), 1, GL_FALSE, glm::value_ptr(lightV));
+        glUniform2f(shaderProgram->getUniform("shadowMapSize"), ShadowMap::SM_WIDTH, ShadowMap::SM_HEIGHT);
 
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, gameManager.getShadowMap()->getShadowMap());
@@ -220,27 +219,13 @@ void ShaderManager::renderShadowPass(std::shared_ptr<GameObject> objToRender, co
 		GameManager& gameManager = GameManager::instance();
 		GameWorld& gameWorld = gameManager.getGameWorld();
 
-		// Point lights
-		// TODO(rgarmsen2295): Add point lights back
-
-		// Directional lights
-		// TODO(rgarmsen2295): Implement more cleanly using "uniform buffer objects"
 		const std::vector<std::shared_ptr<Light>>& directionalLights = gameWorld.getDirectionalLights();
 		int numDirectionLights = directionalLights.size();
 
-
-
-
-		//TODO(nurgan) check +/- if SM not working
         std::shared_ptr<Light> light = directionalLights.at(0);
 
-        //TODO(nurgan) create light P and V!
-        //TODO(nurgan) calculate good values for the ortho projection
         glm::mat4 lightP = calculateLightProjection(light);
-
-
         glm::mat4 lightV = calculateLightView(light);
-
 
 		glUniformMatrix4fv(shaderProgram->getUniform("lightP"), 1, GL_FALSE, glm::value_ptr(lightP));
 		glUniformMatrix4fv(shaderProgram->getUniform("lightV"), 1, GL_FALSE, glm::value_ptr(lightV));
@@ -255,76 +240,34 @@ void ShaderManager::renderShadowPass(std::shared_ptr<GameObject> objToRender, co
 
 		glUniformMatrix4fv(shaderProgram->getUniform("M"), 1, GL_FALSE, glm::value_ptr(M->topMatrix()));
 
-		// Draw bunny
-		// TODO(rgarmsen): Make shape not need the shader program
 		shape->draw(shaderProgram);
-        //TODO(nurgan) check if draw is OK, or if I need a shadow mapping draw
 
 		M->popMatrix();
 
 		unbindShader();
 
-        //glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
 	}
 }
 
 glm::mat4 ShaderManager::calculateLightView(std::shared_ptr<Light> light) {
-    //TODO(nurgan) check +/- if SM not working
-    //glm::mat4 lightV = glm::lookAt(light->position + glm::vec3(0.0, 25.0, 0.0), light->position + glm::vec3(0.0, 25.0, 0.0) + light->orientation, glm::vec3(0.0, 1.0, 0.0));
-    //glm::vec3 smLightPos = light->position + glm::vec3(0.0, halfDiagonal - light->position.y, 0.0);
-
-    float halfDiagonal = getViewFrustumMaxDiagonal() / 2.0f;
 
     Camera camera = GameManager::instance().getCamera();
-    //glm::vec3 camOrientation = glm::normalize(camera.getLookAt() - camera.getEye());
-    //glm::vec3 camOrientation = camera.getLookAt();
-    //glm::vec3 lightOrientation = glm::normalize(-light->orientation);
-    //float heightFac = halfDiagonal / lightOrientation.y;
-
-	//glm::vec3 camOrientationNoY = glm::normalize(glm::vec3(camera.getLookAt().x, 0.0f, camera.getLookAt().z));
-	//glm::vec3 camOrientationNoY = glm::normalize(glm::vec3(-std::abs(camOrientation.x), 0.0f, -std::abs(camOrientation.z)));
-
-	//glm::vec3 smMiddle = camera.getEye() + camOrientationNoY * halfDiagonal;
     glm::vec3 smMiddle = calculateShadowMapMid();
-    //glm::vec3 smLightPos = smMiddle + lightOrientation * heightFac;
     glm::vec3 smLightPos = calculateShadowMapLightPos(light);
-    //glm::mat4 lightV = glm::lookAt(smLightPos, smLightPos + light->orientation, glm::vec3(0.0, 1.0, 0.0));
     glm::mat4 lightV = glm::lookAt(smLightPos, smMiddle, glm::vec3(0.0, 1.0, 0.0));
-
-    /*
-    std::cout << "SM light pos " << smLightPos.x << " "  << smLightPos.y << " " << smLightPos.z << std::endl;
-    std::cout << "light orientation " << light->orientation.x << " "<< light->orientation.y << " "<< light->orientation.z << std::endl;
-    std::cout << "SM mid "  << smMiddle.x << " "  << smMiddle.y << " " << smMiddle.z << std::endl;
-    std::cout << "cam orientation "  << camera.getLookAt().x << " "  << camera.getLookAt().y << " " << camera.getLookAt().z << std::endl;
-    std::cout << "cam POS "  << camera.getEye().x << " "  << camera.getEye().y << " " << camera.getEye().z << std::endl;
-    std::cout << "cam LA "  << camera.getLookAt().x << " "  << camera.getLookAt().y << " " << camera.getLookAt().z << std::endl;
-    std::cout << "hd " << halfDiagonal << std::endl;
-    */
-
-    // print camera position and lookAt to check why orientation is bs
-
-    //glm::vec3 lpos = glm::vec3(0.0, 30.0, 0.0);
-    //glm::vec3 lor = glm::normalize(glm::vec3(1.0, 1.0, 0.0));
-    //glm::vec3 lup = glm::vec3(0.0, 0.0, 1.0);
-    //glm::mat4 lightV = glm::lookAt(lpos, lpos - lor, lup);
 
     return lightV;
 }
 
 glm::mat4 ShaderManager::calculateLightProjection(std::shared_ptr<Light> light) {
-    //glm::mat4 lightP = glm::ortho(-50.0, 50.0, -50.0, 50.0, 0.1, 150.0);
+
     float viewFrustumMaxDiagonal = getViewFrustumMaxDiagonal();
     float halfDiagonal = viewFrustumMaxDiagonal / 2.0;
 
     glm::vec3 lightSmMid = calculateShadowMapLightPos(light) - calculateShadowMapMid();
-
     float dist = glm::length(lightSmMid);
 
-    //glm::mat4 lightP = glm::ortho(-halfDiagonal, halfDiagonal, -halfDiagonal, halfDiagonal, 0.1f, viewFrustumMaxDiagonal*2.0f);
     glm::mat4 lightP = glm::ortho(-halfDiagonal, halfDiagonal, -halfDiagonal, halfDiagonal, 0.1f, dist*2.0f);
-
-    //TODO(nurgan): GET THE FUCKING FAR PLANE FOR THE LIGHT WORKING AND WHOOP WHOOP WE GOOOD
 
     return lightP;
 }
@@ -332,10 +275,7 @@ glm::mat4 ShaderManager::calculateLightProjection(std::shared_ptr<Light> light) 
 glm::vec3 ShaderManager::calculateShadowMapMid() {
 
     Camera camera = GameManager::instance().getCamera();
-
     glm::vec3 camOrientationNoY = glm::normalize(glm::vec3(camera.getLookAt().x, 0.0f, camera.getLookAt().z));
-    //glm::vec3 camOrientationNoY = glm::normalize(glm::vec3(-std::abs(camOrientation.x), 0.0f, -std::abs(camOrientation.z)));
-
     glm::vec3 smMiddle = camera.getEye() + camOrientationNoY * (getViewFrustumMaxDiagonal() / 2.0f);
 
     return smMiddle;
@@ -345,15 +285,14 @@ glm::vec3 ShaderManager::calculateShadowMapLightPos(std::shared_ptr<Light> light
 
     glm::vec3 lightOrientation = glm::normalize(-light->orientation);
     float heightFac = (getViewFrustumMaxDiagonal() / 2.0f) / lightOrientation.y;
-
     glm::vec3 smLightPos = calculateShadowMapMid() + lightOrientation * heightFac;
 
     return smLightPos;
 }
 
 float ShaderManager::getViewFrustumMaxDiagonal() {
-    float farNearDist = GameManager::playerFarPlane - GameManager::playerNearPlane;
-    return std::sqrt(2 * (farNearDist * farNearDist));
+    float farNearDist = GameManager::cullFarPlane - GameManager::nearPlane;
+    return farNearDist;
 }
 
 LightType ShaderManager::stringToLightType(std::string type) {

--- a/src/ShaderManager.cpp
+++ b/src/ShaderManager.cpp
@@ -292,6 +292,7 @@ glm::mat4 ShaderManager::calculateLightView(std::shared_ptr<Light> light) {
     //glm::mat4 lightV = glm::lookAt(smLightPos, smLightPos + light->orientation, glm::vec3(0.0, 1.0, 0.0));
     glm::mat4 lightV = glm::lookAt(smLightPos, smMiddle, glm::vec3(0.0, 1.0, 0.0));
 
+    /*
     std::cout << "SM light pos " << smLightPos.x << " "  << smLightPos.y << " " << smLightPos.z << std::endl;
     std::cout << "light orientation " << light->orientation.x << " "<< light->orientation.y << " "<< light->orientation.z << std::endl;
     std::cout << "SM mid "  << smMiddle.x << " "  << smMiddle.y << " " << smMiddle.z << std::endl;
@@ -299,6 +300,7 @@ glm::mat4 ShaderManager::calculateLightView(std::shared_ptr<Light> light) {
     std::cout << "cam POS "  << camera.getEye().x << " "  << camera.getEye().y << " " << camera.getEye().z << std::endl;
     std::cout << "cam LA "  << camera.getLookAt().x << " "  << camera.getLookAt().y << " " << camera.getLookAt().z << std::endl;
     std::cout << "hd " << halfDiagonal << std::endl;
+    */
 
     // print camera position and lookAt to check why orientation is bs
 

--- a/src/ShaderManager.cpp
+++ b/src/ShaderManager.cpp
@@ -139,6 +139,7 @@ void ShaderManager::unbindShader() {
 void ShaderManager::renderObject(std::shared_ptr<GameObject> objToRender, const std::string& shaderName, const std::shared_ptr<Shape> shape,
  const std::shared_ptr<Material> material, std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> V, std::shared_ptr<MatrixStack> M) {
 	if (objToRender != NULL) {
+
 		const std::shared_ptr<Program> shaderProgram = bindShader(shaderName);
 
 		// Bind perspective and view tranforms
@@ -171,6 +172,40 @@ void ShaderManager::renderObject(std::shared_ptr<GameObject> objToRender, const 
 		glUniform3f(shaderProgram->getUniform("MatSpc"), material->rSpc, material->gSpc, material->bSpc);
 		glUniform1f(shaderProgram->getUniform("MatShiny"), material->shininess);
 
+
+
+        //glm::mat4 lightP = glm::ortho(-50.0, 50.0, -50.0, 50.0, 0.1, 150.0);
+        float farNearDist = GameManager::playerFarPlane - GameManager::playerNearPlane;
+        float viewFrustumMaxDiagonal = std::sqrt(2 * (farNearDist * farNearDist));
+        float halfDiagonal = viewFrustumMaxDiagonal / 2.0;
+        glm::mat4 lightP = glm::ortho(-halfDiagonal, halfDiagonal, -halfDiagonal, halfDiagonal, 0.1f, viewFrustumMaxDiagonal);
+
+        //TODO(nurgan) check +/- if SM not working
+        const std::shared_ptr<Light> light = directionalLights.at(0);
+        //glm::mat4 lightV = glm::lookAt(light->position + glm::vec3(0.0, 25.0, 0.0), light->position + glm::vec3(0.0, 25.0, 0.0) + light->orientation, glm::vec3(0.0, 1.0, 0.0));
+
+        //glm::vec3 smLightPos = light->position + glm::vec3(0.0, halfDiagonal - light->position.y, 0.0);
+
+        Camera camera = gameManager.getCamera();
+        glm::vec3 camOrientation = glm::normalize(camera.getLookAt() - camera.getEye());
+        glm::vec3 lightOrientation = glm::normalize(-light->orientation);
+        float heightFac = halfDiagonal / lightOrientation.y;
+        glm::vec3 smLightPos = camera.getEye() + camOrientation * halfDiagonal + lightOrientation * heightFac;
+        glm::mat4 lightV = glm::lookAt(smLightPos, smLightPos + light->orientation, glm::vec3(0.0, 1.0, 0.0));
+
+        //glm::vec3 lpos = glm::vec3(0.0, 30.0, 0.0);
+        //glm::vec3 lor = glm::normalize(glm::vec3(1.0, 1.0, 0.0));
+        //glm::vec3 lup = glm::vec3(0.0, 0.0, 1.0);
+        //glm::mat4 lightV = glm::lookAt(lpos, lpos - lor, lup);
+
+        glUniformMatrix4fv(shaderProgram->getUniform("lightP"), 1, GL_FALSE, glm::value_ptr(lightP));
+        glUniformMatrix4fv(shaderProgram->getUniform("lightV"), 1, GL_FALSE, glm::value_ptr(lightV));
+
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, gameManager.getShadowMap()->getShadowMap());
+
+        glUniform1i(shaderProgram->getUniform("shadowMapTex"), 0);
+
 		// Set up and bind model transform
 		M->pushMatrix();
 		M->loadIdentity();
@@ -191,6 +226,80 @@ void ShaderManager::renderObject(std::shared_ptr<GameObject> objToRender, const 
 		M->popMatrix();
 
 		unbindShader();
+	}
+}
+
+void ShaderManager::renderShadowPass(std::shared_ptr<GameObject> objToRender, const std::shared_ptr<Shape> shape,
+					  std::shared_ptr<MatrixStack> M){
+	if (objToRender != NULL) {
+
+		const std::shared_ptr<Program> shaderProgram = bindShader(ShaderManager::shadowPassShaderName);
+
+		// Set up lights
+		GameManager& gameManager = GameManager::instance();
+		GameWorld& gameWorld = gameManager.getGameWorld();
+
+		// Point lights
+		// TODO(rgarmsen2295): Add point lights back
+
+		// Directional lights
+		// TODO(rgarmsen2295): Implement more cleanly using "uniform buffer objects"
+		const std::vector<std::shared_ptr<Light>>& directionalLights = gameWorld.getDirectionalLights();
+		int numDirectionLights = directionalLights.size();
+
+		//TODO(nurgan) create light P and V!
+		//TODO(nurgan) calculate good values for the ortho projection
+        //glm::mat4 lightP = glm::ortho(-50.0, 50.0, -50.0, 50.0, 0.1, 150.0);
+        float farNearDist = GameManager::playerFarPlane - GameManager::playerNearPlane;
+        float viewFrustumMaxDiagonal = std::sqrt(2 * (farNearDist * farNearDist));
+        float halfDiagonal = viewFrustumMaxDiagonal / 2.0;
+        glm::mat4 lightP = glm::ortho(-halfDiagonal, halfDiagonal, -halfDiagonal, halfDiagonal, 0.1f, viewFrustumMaxDiagonal);
+
+		//TODO(nurgan) check +/- if SM not working
+		const std::shared_ptr<Light> light = directionalLights.at(0);
+		//glm::mat4 lightV = glm::lookAt(light->position + glm::vec3(0.0, 25.0, 0.0), light->position + glm::vec3(0.0, 25.0, 0.0) + light->orientation, glm::vec3(0.0, 1.0, 0.0));
+        //glm::vec3 smLightPos = light->position + glm::vec3(0.0, halfDiagonal - light->position.y, 0.0);
+
+        Camera camera = gameManager.getCamera();
+        glm::vec3 camOrientation = glm::normalize(camera.getLookAt() - camera.getEye());
+        glm::vec3 lightOrientation = glm::normalize(-light->orientation);
+        float heightFac = halfDiagonal / lightOrientation.y;
+        glm::vec3 smLightPos = camera.getEye() + camOrientation * halfDiagonal + lightOrientation * heightFac;
+        glm::mat4 lightV = glm::lookAt(smLightPos, smLightPos + light->orientation, glm::vec3(0.0, 1.0, 0.0));
+
+
+        //glm::vec3 lpos = glm::vec3(0.0, 30.0, 0.0);
+        //glm::vec3 lor = glm::normalize(glm::vec3(1.0, 1.0, 0.0));
+        //glm::vec3 lup = glm::vec3(0.0, 0.0, 1.0);
+        //glm::mat4 lightV = glm::lookAt(lpos, lpos - lor, lup);
+
+        std::cout << "pos " << smLightPos.x << " "  << smLightPos.y << " " << smLightPos.z << " orientation " << light->orientation.x << " "<< light->orientation.y << " "<< light->orientation.z << std::endl;
+        std::cout << "hd " << halfDiagonal << std::endl;
+
+		glUniformMatrix4fv(shaderProgram->getUniform("lightP"), 1, GL_FALSE, glm::value_ptr(lightP));
+		glUniformMatrix4fv(shaderProgram->getUniform("lightV"), 1, GL_FALSE, glm::value_ptr(lightV));
+
+		// Set up and bind model transform
+		M->pushMatrix();
+		M->loadIdentity();
+
+		M->translate(objToRender->getPosition());
+		M->scale(objToRender->getScale());
+		M->rotate(objToRender->getYAxisRotation(), glm::vec3(0.0f, 1.0f, 0.0f));
+
+		glUniformMatrix4fv(shaderProgram->getUniform("M"), 1, GL_FALSE, glm::value_ptr(M->topMatrix()));
+
+		// Draw bunny
+		// TODO(rgarmsen): Make shape not need the shader program
+		shape->draw(shaderProgram);
+        //TODO(nurgan) check if draw is OK, or if I need a shadow mapping draw
+
+		M->popMatrix();
+
+		unbindShader();
+
+        //glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
 	}
 }
 

--- a/src/ShaderManager.h
+++ b/src/ShaderManager.h
@@ -81,8 +81,13 @@ public:
 	void renderObject(std::shared_ptr<GameObject> objToRender, const std::string& shaderName, const std::shared_ptr<Shape> shape,
  	 const std::shared_ptr<Material> material, std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> V, std::shared_ptr<MatrixStack> M);
 
+	// Render the given object to the shadowmap
+	void renderShadowPass(std::shared_ptr<GameObject> objToRender, const std::shared_ptr<Shape> shape,
+						  std::shared_ptr<MatrixStack> M);
 	// Returns an actual LightType enum value of the given string
 	static LightType stringToLightType(std::string type);
+
+    static constexpr const char* shadowPassShaderName = "shadowPass";
 
 private:
 

--- a/src/ShaderManager.h
+++ b/src/ShaderManager.h
@@ -106,6 +106,20 @@ private:
 	// A hash map of the currently linked shader programs. The key is the shader program name and the value is a pointer to the Program
 	std::unordered_map<std::string, std::shared_ptr<Program>> shaderPrograms;
 
+	// Calculate the View Matrix for the given light (for Shadow Mapping)
+	glm::mat4 calculateLightView(std::shared_ptr<Light> light);
+
+	// Calculate the Projection Matrix for the given light (for Shadow Mapping)
+	glm::mat4 calculateLightProjection(std::shared_ptr<Light> light);
+
+    // calculate the "middle" of the shoadow map in world sapce
+    glm::vec3 calculateShadowMapMid();
+
+    // calculate the light position as used for shadow mapping
+    glm::vec3 calculateShadowMapLightPos(std::shared_ptr<Light> light);
+
+	float getViewFrustumMaxDiagonal();
+
 	ShaderManager();
 
 };

--- a/src/ShadowMap.cpp
+++ b/src/ShadowMap.cpp
@@ -1,0 +1,61 @@
+#include "ShadowMap.h"
+#include "WindowManager.h"
+
+ShadowMap::ShadowMap() {
+    //generate the FBO for the shadow depth
+    glGenFramebuffers(1, &shadowMapFBO);
+
+    //generate the texture
+    glGenTextures(1, &shadowMap);
+    glBindTexture(GL_TEXTURE_2D, shadowMap);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, S_WIDTH, S_HEIGHT,
+                 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+
+    //bind with framebuffer's depth buffer
+    glBindFramebuffer(GL_FRAMEBUFFER, shadowMapFBO);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, shadowMap, 0);
+    glDrawBuffer(GL_NONE);
+    glReadBuffer(GL_NONE);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+ShadowMap::~ShadowMap() {
+
+}
+
+void ShadowMap::bindForShadowPass() {
+    glViewport(0, 0, S_WIDTH, S_HEIGHT);
+    glBindFramebuffer(GL_FRAMEBUFFER, shadowMapFBO);
+    glClear(GL_DEPTH_BUFFER_BIT);
+    glCullFace(GL_FRONT);
+
+}
+
+void ShadowMap::bindForDraw() {
+
+
+    //end sm
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    //start
+
+    WindowManager& windowManager = WindowManager::instance();
+
+    glViewport(0, 0, windowManager.getViewWidth(), windowManager.getViewHeight());
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    glCullFace(GL_BACK);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, shadowMap);
+
+}
+
+GLuint ShadowMap::getShadowMap() {
+    return shadowMap;
+}

--- a/src/ShadowMap.cpp
+++ b/src/ShadowMap.cpp
@@ -8,7 +8,7 @@ ShadowMap::ShadowMap() {
     //generate the texture
     glGenTextures(1, &shadowMap);
     glBindTexture(GL_TEXTURE_2D, shadowMap);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, S_WIDTH, S_HEIGHT,
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, SM_WIDTH, SM_HEIGHT,
                  0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
@@ -29,20 +29,13 @@ ShadowMap::~ShadowMap() {
 }
 
 void ShadowMap::bindForShadowPass() {
-    glViewport(0, 0, S_WIDTH, S_HEIGHT);
+    glViewport(0, 0, SM_WIDTH, SM_HEIGHT);
     glBindFramebuffer(GL_FRAMEBUFFER, shadowMapFBO);
     glClear(GL_DEPTH_BUFFER_BIT);
-    glCullFace(GL_FRONT);
-
 }
 
 void ShadowMap::bindForDraw() {
-
-
-    //end sm
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-    //start
 
     WindowManager& windowManager = WindowManager::instance();
 

--- a/src/ShadowMap.h
+++ b/src/ShadowMap.h
@@ -1,0 +1,39 @@
+#ifndef SHADOWMAP_H
+#define SHADOWMAP_H
+
+#include <iostream>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "GLSL.h"
+
+#define GLEW_STATIC
+#include <GL/glew.h>
+
+class ShadowMap {
+
+public:
+
+    ShadowMap();
+
+    ~ShadowMap();
+
+    void bindForShadowPass();
+
+    void bindForDraw();
+
+    GLuint getShadowMap();
+
+
+
+private:
+    GLuint shadowMapFBO;
+
+    GLuint shadowMap;
+
+    //const GLuint S_WIDTH = 2048, S_HEIGHT = 2048;
+    //const GLuint S_WIDTH = 4096, S_HEIGHT = 4096;
+    const GLuint S_WIDTH = 16384, S_HEIGHT = 16384;
+};
+#endif

--- a/src/ShadowMap.h
+++ b/src/ShadowMap.h
@@ -25,15 +25,14 @@ public:
 
     GLuint getShadowMap();
 
-
+    //static constexpr GLuint SM_WIDTH = 4096, SM_WIDTH = 4096;
+    static constexpr GLuint SM_WIDTH = 8192, SM_HEIGHT = 8192;
+    //static constexpr GLuint SM_WIDTH = 16384, SM_WIDTH = 16384;
 
 private:
     GLuint shadowMapFBO;
 
     GLuint shadowMap;
 
-    //const GLuint S_WIDTH = 2048, S_HEIGHT = 2048;
-    //const GLuint S_WIDTH = 4096, S_HEIGHT = 4096;
-    const GLuint S_WIDTH = 16384, S_HEIGHT = 16384;
 };
 #endif

--- a/src/SkyboxRenderComponent.cpp
+++ b/src/SkyboxRenderComponent.cpp
@@ -18,3 +18,7 @@ void SkyboxRenderComponent::draw(std::shared_ptr<MatrixStack> P, std::shared_ptr
     shaderManager.renderObject(holder_, shaderName_, shape_, material_, P, V, M);
     cubemap->unbind();
 }
+
+void SkyboxRenderComponent::renderShadow(std::shared_ptr <MatrixStack> M) {
+    // don't do anything, there is no shadow on the skybox
+}

--- a/src/SkyboxRenderComponent.h
+++ b/src/SkyboxRenderComponent.h
@@ -12,6 +12,8 @@ public:
 
     void draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V);
 
+    void renderShadow(std::shared_ptr<MatrixStack> M);
+
 private:
     Cubemap* cubemap;
 

--- a/src/WallRenderComponent.cpp
+++ b/src/WallRenderComponent.cpp
@@ -15,3 +15,8 @@ void WallRenderComponent::draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<M
 	ShaderManager& shaderManager = ShaderManager::instance();
 	shaderManager.renderObject(holder_, shaderName_, shape_, material_, P, V, M);
 }
+
+void WallRenderComponent::renderShadow(std::shared_ptr <MatrixStack> M) {
+	ShaderManager& shaderManager = ShaderManager::instance();
+	shaderManager.renderShadowPass(holder_, shape_, M);
+}

--- a/src/WallRenderComponent.h
+++ b/src/WallRenderComponent.h
@@ -11,6 +11,8 @@ public:
 
 	void draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V);
 
+	void renderShadow(std::shared_ptr<MatrixStack> M);
+
 private:
 
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
     // Add all static objects before this!!!
     world.init();
 
-    gameManager.setTime(1500.0);
+    gameManager.setTime(15.0);
 
     // Loop until the user closes the window
     int numFramesInSecond = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include "ShapeManager.h"
 #include "MaterialManager.h"
 #include "WindowManager.h"
+#include "ShadowMap.h"
 
 #include "WallPhysicsComponent.h"
 #include "WallRenderComponent.h"
@@ -77,10 +78,14 @@ int main(int argc, char **argv) {
     // Set the current view frustum
     gameManager.setViewFrustum(new ViewFrustum());
 
+    // Set the Shadow Map Object
+    ShadowMap* shadowMap = new ShadowMap();
+    gameManager.setShadowMap(shadowMap);
+
     // Add all static objects before this!!!
     world.init();
 
-    gameManager.setTime(15.0);
+    gameManager.setTime(1500.0);
 
     // Loop until the user closes the window
     int numFramesInSecond = 0;
@@ -120,6 +125,9 @@ int main(int argc, char **argv) {
 
         // Update the window in-case of resizing, etc.
         windowManager.update();
+
+        // Render all objects to shadow map
+        world.renderShadowMap();
 
         // Draw all objects in the world
         world.drawGameObjects();


### PR DESCRIPTION
Added final working version of shadow Mapping.
- uses PCF soft shadows (for each fragment only the corresponding shadow map texel is evaluated (resulting in the hard shadow borders, as in the workshop in class), but also the surrounding texels are evaluated, creating a soft shadow outline)
- added a different far plane value for the actual view frustum and for view frustum culling + shadow mapping
- only remaining issue: view frustum still that big, that the shadow map resolution seems to be very low for the size