### PR TITLE
Collision Detection Update (Spheres vs changes to AABB)

### DIFF
--- a/src/BoundingBox.cpp
+++ b/src/BoundingBox.cpp
@@ -1,5 +1,7 @@
 #include "BoundingBox.h"
 
+#include "PlayerBoundingSphere.h"
+
 BoundingBox::BoundingBox()
 	: objMin_(glm::vec3(0.0f, 0.0f, 0.0f)),
 	objMax_(glm::vec3(0.0f, 0.0f, 0.0f)),
@@ -30,27 +32,51 @@ BoundingBox::BoundingBox(glm::vec3& min, glm::vec3& max)
  * Basic idea + circular versus box collisions sourced from here
  * https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_collision_detection
  */
-bool BoundingBox::checkIntersection(BoundingBox& other) {
-	return (this->min_.x <= other.max_.x && this->max_.x >= other.min_.x) &&
-		(this->min_.y <= other.max_.y && this->max_.y >= other.min_.y) &&
-		(this->min_.z <= other.max_.z && this->max_.z >= other.min_.z);
+bool BoundingBox::checkIntersection(std::shared_ptr<BoundingBox> other) {
+	return (this->min_.x <= other->max_.x && this->max_.x >= other->min_.x) &&
+		(this->min_.y <= other->max_.y && this->max_.y >= other->min_.y) &&
+		(this->min_.z <= other->max_.z && this->max_.z >= other->min_.z);
 }
 
-glm::vec3 BoundingBox::calcReflNormal(BoundingBox& other) {
+glm::vec3 BoundingBox::calcReflNormal(std::shared_ptr<BoundingBox> other, float epsilon) {
    glm::vec3 normal = glm::vec3(0.0, 0.0, 0.0);
-   float epsilon = 0.1f;
+   //float epsilon = 0.1f;
+
+   if (other->isPlayer()) {
+	   std::shared_ptr<PlayerBoundingSphere> sphereBound = std::static_pointer_cast<PlayerBoundingSphere>(other);
+
+	   float x = std::max(min_.x, std::min(sphereBound->center_.x, max_.x));
+	   float y = std::max(min_.y, std::min(sphereBound->center_.y, max_.y));
+	   float z = std::max(min_.z, std::min(sphereBound->center_.z, max_.z));
+
+	   glm::vec3 sphereHit(x, y, z);
+
+	   //check on which side of the bounding box of the object the cookie hit and create normal for reflection
+	   if ((this->min_.x - epsilon <= sphereHit.x && this->min_.x + epsilon >= sphereHit.x) ||
+		   (this->max_.x - epsilon <= sphereHit.x && this->max_.x + epsilon >= sphereHit.x)) {
+		   normal.x = 1.0;
+	   }
+	   if ((this->min_.y - epsilon <= sphereHit.y && this->min_.y + epsilon >= sphereHit.y) ||
+		   (this->max_.y - epsilon <= sphereHit.y && this->max_.y + epsilon >= sphereHit.y)) {
+		   normal.y = 1.0;
+	   }
+	   if ((this->min_.z - epsilon <= sphereHit.z && this->min_.z + epsilon >= sphereHit.z) ||
+		   (this->max_.z - epsilon <= sphereHit.z && this->max_.z + epsilon >= sphereHit.z)) {
+		   normal.z = 1.0;
+	   }
+   }
 
    //check on which side of the bounding box of the object the cookie hit and create normal for reflection
-   if((this->min_.x - epsilon <= other.max_.x && this->min_.x + epsilon >= other.max_.x) ||
-           (this->max_.x - epsilon <= other.min_.x && this->max_.x + epsilon >= other.min_.x)) {
+   if((this->min_.x - epsilon <= other->max_.x && this->min_.x + epsilon >= other->max_.x) ||
+           (this->max_.x - epsilon <= other->min_.x && this->max_.x + epsilon >= other->min_.x)) {
        normal.x = 1.0;
    }
-   if((this->min_.y - epsilon <= other.max_.y && this->min_.y + epsilon >= other.max_.y) ||
-           (this->max_.y - epsilon <= other.min_.y && this->max_.y + epsilon >= other.min_.y)){
+   if((this->min_.y - epsilon <= other->max_.y && this->min_.y + epsilon >= other->max_.y) ||
+           (this->max_.y - epsilon <= other->min_.y && this->max_.y + epsilon >= other->min_.y)){
        normal.y = 1.0;
    }
-   if((this->min_.z - epsilon <= other.max_.z && this->min_.z + epsilon >= other.max_.z) ||
-           (this->max_.z - epsilon <= other.min_.z && this->max_.z + epsilon >= other.min_.z)){
+   if((this->min_.z - epsilon <= other->max_.z && this->min_.z + epsilon >= other->max_.z) ||
+           (this->max_.z - epsilon <= other->min_.z && this->max_.z + epsilon >= other->min_.z)){
        normal.z = 1.0;
    }
 
@@ -81,4 +107,8 @@ void BoundingBox::update(glm::mat4& transform) {
 
 	min_ = glm::vec3(minX, minY, minZ);
 	max_ = glm::vec3(maxX, maxY, maxZ);
+}
+
+bool BoundingBox::isPlayer() {
+	return false;
 }

--- a/src/BoundingBox.cpp
+++ b/src/BoundingBox.cpp
@@ -40,7 +40,6 @@ bool BoundingBox::checkIntersection(std::shared_ptr<BoundingBox> other) {
 
 glm::vec3 BoundingBox::calcReflNormal(std::shared_ptr<BoundingBox> other, float epsilon) {
    glm::vec3 normal = glm::vec3(0.0, 0.0, 0.0);
-   //float epsilon = 0.1f;
 
    if (other->isPlayer()) {
 	   std::shared_ptr<PlayerBoundingSphere> sphereBound = std::static_pointer_cast<PlayerBoundingSphere>(other);

--- a/src/BoundingBox.cpp
+++ b/src/BoundingBox.cpp
@@ -38,7 +38,7 @@ bool BoundingBox::checkIntersection(BoundingBox& other) {
 
 glm::vec3 BoundingBox::calcReflNormal(BoundingBox& other) {
    glm::vec3 normal = glm::vec3(0.0, 0.0, 0.0);
-   float epsilon = 1.5f;
+   float epsilon = 0.1f;
 
    //check on which side of the bounding box of the object the cookie hit and create normal for reflection
    if((this->min_.x - epsilon <= other.max_.x && this->min_.x + epsilon >= other.max_.x) ||

--- a/src/BoundingBox.h
+++ b/src/BoundingBox.h
@@ -6,8 +6,10 @@
 #include "glm/mat4x4.hpp"
 #include "glm/gtc/matrix_transform.hpp"
 
+#include <algorithm>
 #include <float.h>
 #include <iostream>
+#include <memory>
 
 class BoundingBox {
 public:
@@ -37,13 +39,15 @@ public:
 	~BoundingBox() {}
 
 	// Checks if the BoundingBox intersects with the passed BoundingBox's coordinates
-	virtual bool checkIntersection(BoundingBox& other);
+	virtual bool checkIntersection(std::shared_ptr<BoundingBox> other);
 
    // Checks which side of `this` bounding box was hit and creates normal for reflection
-   glm::vec3 calcReflNormal(BoundingBox& other);
+   glm::vec3 calcReflNormal(std::shared_ptr<BoundingBox> other, float epsilon);
 
 	// Updates the bounding box min, max, and boxPoints based on the passed transform
-	void update(glm::mat4& transform);
+	virtual void update(glm::mat4& transform);
+
+	virtual bool isPlayer();
 };
 
 #endif

--- a/src/BoundingBox.h
+++ b/src/BoundingBox.h
@@ -37,7 +37,7 @@ public:
 	~BoundingBox() {}
 
 	// Checks if the BoundingBox intersects with the passed BoundingBox's coordinates
-	bool checkIntersection(BoundingBox& other);
+	virtual bool checkIntersection(BoundingBox& other);
 
    // Checks which side of `this` bounding box was hit and creates normal for reflection
    glm::vec3 calcReflNormal(BoundingBox& other);

--- a/src/CookiePhysicsComponent.cpp
+++ b/src/CookiePhysicsComponent.cpp
@@ -49,11 +49,11 @@ void CookiePhysicsComponent::updatePhysics(float deltaTime) {
 
         if (objTypeHit == GameObjectType::STATIC_OBJECT || objTypeHit == GameObjectType::DYNAMIC_OBJECT) {
 
-            BoundingBox* objBB = objHit->getBoundingBox();
-            BoundingBox* cookieBB = holder_->getBoundingBox();
+            std::shared_ptr<BoundingBox> objBB = objHit->getBoundingBox();
+            std::shared_ptr<BoundingBox> cookieBB = holder_->getBoundingBox();
             MaterialManager materialManager = MaterialManager::instance();
 
-            glm::vec3 normal = objBB->calcReflNormal(*cookieBB);
+            glm::vec3 normal = objBB->calcReflNormal(cookieBB, 1.5f);
             holder_->direction = glm::reflect(holder_->direction, normal);
 
             newPosition = oldPosition + (holder_->velocity * holder_->direction * deltaTime);

--- a/src/FireHydrantPhysicsComponent.cpp
+++ b/src/FireHydrantPhysicsComponent.cpp
@@ -86,10 +86,10 @@ void FireHydrantPhysicsComponent::updatePhysics(float deltaTime) {
          audioManager.playEffect("FireHydrant Clank");
       } else if (objTypeHit == GameObjectType::STATIC_OBJECT ||
                  objTypeHit == GameObjectType::DYNAMIC_OBJECT) {
-         BoundingBox* objBB = objHit->getBoundingBox();
-         BoundingBox* thisBB = holder_->getBoundingBox();
+		 std::shared_ptr<BoundingBox> objBB = objHit->getBoundingBox();
+		 std::shared_ptr<BoundingBox> thisBB = holder_->getBoundingBox();
 
-         glm::vec3 normal = objBB->calcReflNormal(*thisBB);
+         glm::vec3 normal = objBB->calcReflNormal(thisBB, 1.5f);
          holder_->direction = glm::reflect(holder_->direction, normal);
          animRotAxis = glm::cross(holder_->direction, glm::vec3(0, 1, 0));
 

--- a/src/FireHydrantPhysicsComponent.cpp
+++ b/src/FireHydrantPhysicsComponent.cpp
@@ -86,8 +86,8 @@ void FireHydrantPhysicsComponent::updatePhysics(float deltaTime) {
          audioManager.playEffect("FireHydrant Clank");
       } else if (objTypeHit == GameObjectType::STATIC_OBJECT ||
                  objTypeHit == GameObjectType::DYNAMIC_OBJECT) {
-		 std::shared_ptr<BoundingBox> objBB = objHit->getBoundingBox();
-		 std::shared_ptr<BoundingBox> thisBB = holder_->getBoundingBox();
+         std::shared_ptr<BoundingBox> objBB = objHit->getBoundingBox();
+         std::shared_ptr<BoundingBox> thisBB = holder_->getBoundingBox();
 
          glm::vec3 normal = objBB->calcReflNormal(thisBB, 1.5f);
          holder_->direction = glm::reflect(holder_->direction, normal);

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -104,10 +104,9 @@ glm::vec3& GameObject::getScale() {
 }
 
 void GameObject::setOrientAngle(float orientAngle) {
-	static glm::vec3 yAxis(0.0f, 1.0f, 0.0f);
+   static glm::vec3 yAxis(0.0f, 1.0f, 0.0f);
 
-	std::shared_ptr<BoundingBox> objectBB = getBoundingBox();
-
+   std::shared_ptr<BoundingBox> objectBB = getBoundingBox();
    if (objectBB != nullptr) {
       MatrixTransform orientTransform;
       orientTransform.setRotate(orientAngle, yAxis);
@@ -138,15 +137,6 @@ void GameObject::setScale(glm::vec3& newScale) {
 
 void GameObject::setYAxisRotation(float angle) {
 	static glm::vec3 yAxis(0.0f, 1.0f, 0.0f);
-
-	std::shared_ptr<BoundingBox> objectBB = getBoundingBox();
-
-   if (objectBB != nullptr) {
-      //MatrixTransform orientTransform;
-      //orientTransform.setRotate(angle, yAxis);
-      //render_->getShape()->findAndSetMinAndMax(orientTransform.getTransform());
-      //physics_->initBoundingBox(render_->getShape()->getMin(), render_->getShape()->getMax());
-   }
 
 	yRotationAngle_ = angle;
 	transform.setRotate(angle, yAxis);

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -106,9 +106,9 @@ glm::vec3& GameObject::getScale() {
 void GameObject::setOrientAngle(float orientAngle) {
 	static glm::vec3 yAxis(0.0f, 1.0f, 0.0f);
 
-   BoundingBox* objectBB = getBoundingBox();
+	std::shared_ptr<BoundingBox> objectBB = getBoundingBox();
 
-   if (objectBB != NULL) {
+   if (objectBB != nullptr) {
       MatrixTransform orientTransform;
       orientTransform.setRotate(orientAngle, yAxis);
       render_->getShape()->findAndSetMinAndMax(orientTransform.getTransform());
@@ -139,9 +139,9 @@ void GameObject::setScale(glm::vec3& newScale) {
 void GameObject::setYAxisRotation(float angle) {
 	static glm::vec3 yAxis(0.0f, 1.0f, 0.0f);
 
-	BoundingBox* objectBB = getBoundingBox();
+	std::shared_ptr<BoundingBox> objectBB = getBoundingBox();
 
-   if (objectBB != NULL) {
+   if (objectBB != nullptr) {
       //MatrixTransform orientTransform;
       //orientTransform.setRotate(angle, yAxis);
       //render_->getShape()->findAndSetMinAndMax(orientTransform.getTransform());
@@ -244,17 +244,17 @@ RenderComponent* GameObject::getRenderComponent() {
 bool GameObject::checkIntersection(std::shared_ptr<GameObject> otherObj) {	
 	PhysicsComponent* otherObjPhysics = otherObj->physics_;
 	if (physics_ != NULL && otherObjPhysics != NULL) {
-		return physics_->getBoundingBox().checkIntersection(otherObjPhysics->getBoundingBox());
+		return physics_->getBoundingBox()->checkIntersection(otherObjPhysics->getBoundingBox());
 	}
 
 	return false;
 }
 
-BoundingBox* GameObject::getBoundingBox() {
+std::shared_ptr<BoundingBox> GameObject::getBoundingBox() {
    if (physics_) {
-      return &physics_->getBoundingBox();
+      return physics_->getBoundingBox();
    }
-   return NULL;
+   return nullptr;
 }
 
 void GameObject::triggerDeliveryAnimation() {

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -142,10 +142,10 @@ void GameObject::setYAxisRotation(float angle) {
 	BoundingBox* objectBB = getBoundingBox();
 
    if (objectBB != NULL) {
-      MatrixTransform orientTransform;
-      orientTransform.setRotate(angle, yAxis);
-      render_->getShape()->findAndSetMinAndMax(orientTransform.getTransform());
-      physics_->initBoundingBox(render_->getShape()->getMin(), render_->getShape()->getMax());
+      //MatrixTransform orientTransform;
+      //orientTransform.setRotate(angle, yAxis);
+      //render_->getShape()->findAndSetMinAndMax(orientTransform.getTransform());
+      //physics_->initBoundingBox(render_->getShape()->getMin(), render_->getShape()->getMax());
    }
 
 	yRotationAngle_ = angle;

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -114,7 +114,7 @@ public:
 
     // Returns the BoundingBox associated with the object if it exists, otherwise returns |NULL|
     // TRY TO AVOID USING THIS IF POSSIBLE, SHOULD BE REMOVED AT SOME POINT, BB LOGIC ONLY IN PHYSICSCOMPONENT
-    BoundingBox* getBoundingBox();
+    std::shared_ptr<BoundingBox> getBoundingBox();
 
 private:
 

--- a/src/OctreeNode.cpp
+++ b/src/OctreeNode.cpp
@@ -23,7 +23,7 @@ void OctreeNode::createEnclosingRegionForRoot() {
 
    // Find the smallest min and max from every object that will be in the tree
    for (std::shared_ptr<GameObject> obj : objsNotInTree_) {
-      if (obj->getBoundingBox() != NULL) {
+      if (obj->getBoundingBox() != nullptr) {
          glm::vec3& objMin = obj->getBoundingBox()->min_;
          glm::vec3& objMax = obj->getBoundingBox()->max_;
 
@@ -41,10 +41,10 @@ void OctreeNode::createEnclosingRegionForRoot() {
 }
 
 bool OctreeNode::contains(const std::shared_ptr<GameObject> obj) {
-   BoundingBox* objBoundBox = obj->getBoundingBox();
+	std::shared_ptr<BoundingBox> objBoundBox = obj->getBoundingBox();
 
    // Object has no bounding box
-   if (objBoundBox == NULL) {
+   if (objBoundBox == nullptr) {
       return false;
    }
 

--- a/src/OctreeNode.cpp
+++ b/src/OctreeNode.cpp
@@ -41,7 +41,7 @@ void OctreeNode::createEnclosingRegionForRoot() {
 }
 
 bool OctreeNode::contains(const std::shared_ptr<GameObject> obj) {
-	std::shared_ptr<BoundingBox> objBoundBox = obj->getBoundingBox();
+   std::shared_ptr<BoundingBox> objBoundBox = obj->getBoundingBox();
 
    // Object has no bounding box
    if (objBoundBox == nullptr) {

--- a/src/PhysicsComponent.cpp
+++ b/src/PhysicsComponent.cpp
@@ -3,15 +3,15 @@
 #include "GameObject.h"
 
 void PhysicsComponent::initBoundingBox(glm::vec3& minBoundPt, glm::vec3& maxBoundPt) {
-	boundBox_ = BoundingBox(minBoundPt, maxBoundPt);
+	boundBox_ = std::make_shared<BoundingBox>(BoundingBox(minBoundPt, maxBoundPt));
 	updateBoundingBox();
 }
 
 void PhysicsComponent::updateBoundingBox() {
 	MatrixTransform& transform = holder_->transform;
-	boundBox_.update(transform.getBoundingBoxTransform());
+	boundBox_->update(transform.getBoundingBoxTransform());
 }
 
-BoundingBox& PhysicsComponent::getBoundingBox() {
+std::shared_ptr<BoundingBox> PhysicsComponent::getBoundingBox() {
 	return boundBox_;
 }

--- a/src/PhysicsComponent.cpp
+++ b/src/PhysicsComponent.cpp
@@ -8,7 +8,7 @@ void PhysicsComponent::initBoundingBox(glm::vec3& minBoundPt, glm::vec3& maxBoun
 }
 
 void PhysicsComponent::updateBoundingBox() {
-	MatrixTransform transform = holder_->transform;
+	MatrixTransform& transform = holder_->transform;
 	boundBox_.update(transform.getBoundingBoxTransform());
 }
 

--- a/src/PhysicsComponent.h
+++ b/src/PhysicsComponent.h
@@ -20,7 +20,7 @@ public:
 	void updateBoundingBox();
 
 	// Returns a reference to the object's bounding box
-	BoundingBox& getBoundingBox();
+	std::shared_ptr<BoundingBox> getBoundingBox();
 
 	// Initializes the object's physics specific to the implementing component
 	virtual void initObjectPhysics() = 0;
@@ -34,7 +34,7 @@ public:
 protected:
 
 	// The bounding box associated with the object
-	BoundingBox boundBox_;
+	std::shared_ptr<BoundingBox> boundBox_;
 
 };
 

--- a/src/PhysicsComponent.h
+++ b/src/PhysicsComponent.h
@@ -14,7 +14,7 @@ public:
 	virtual ~PhysicsComponent() {}
 
 	// Initializes the internal bounding box based off the passed min and max points
-	void initBoundingBox(glm::vec3& minBoundPt, glm::vec3& maxBoundPt);
+	virtual void initBoundingBox(glm::vec3& minBoundPt, glm::vec3& maxBoundPt);
 
 	// Updates the object's bounding box according to the holding object's current transform
 	void updateBoundingBox();
@@ -31,7 +31,7 @@ public:
 	// starts the delivery animation
 	virtual void startDeliveryAnimation() = 0;
 
-private:
+protected:
 
 	// The bounding box associated with the object
 	BoundingBox boundBox_;

--- a/src/PlayerBoundingSphere.cpp
+++ b/src/PlayerBoundingSphere.cpp
@@ -1,0 +1,42 @@
+#include "PlayerBoundingSphere.h"
+
+PlayerBoundingSphere::PlayerBoundingSphere() : BoundingBox() {
+	objCenter_ = (objMin_ + objMax_) / 2.0f;
+	center_ = objCenter_;
+	radius_ = abs(glm::length(objMax_ - center_));
+}
+
+PlayerBoundingSphere::PlayerBoundingSphere(glm::vec3& min, glm::vec3& max) : BoundingBox(min, max) {
+	std::cout << "HERFSXC" << std::endl;
+	objCenter_ = (min + max) / 2.0f;
+	center_ = objCenter_;
+	radius_ = abs(glm::length(max - center_));
+}
+
+PlayerBoundingSphere::~PlayerBoundingSphere() {}
+
+// Checks if the BoundingBox intersects with the passed BoundingBox's coordinates
+bool PlayerBoundingSphere::checkIntersection(std::shared_ptr<BoundingBox> other) {
+	//std::cout << "HERE" << std::endl;
+	// get box closest point to sphere center by clamping
+	float x = std::max(other->min_.x, std::min(center_.x, other->max_.x));
+	float y = std::max(other->min_.y, std::min(center_.y, other->max_.y));
+	float z = std::max(other->min_.z, std::min(center_.z, other->max_.z));
+
+	float distance = std::sqrt((x - center_.x) * (x - center_.x) +
+		(y - center_.y) * (y - center_.y) +
+		(z - center_.z) * (z - center_.z));
+
+	return distance < radius_;
+}
+
+// Updates the bounding box min, max, and boxPoints based on the passed transform
+void PlayerBoundingSphere::update(glm::mat4& transform) {
+	BoundingBox::update(transform);
+
+	center_ = transform * glm::vec4(objCenter_, 1.0);
+}
+
+bool PlayerBoundingSphere::isPlayer() {
+	return true;
+}

--- a/src/PlayerBoundingSphere.cpp
+++ b/src/PlayerBoundingSphere.cpp
@@ -15,17 +15,21 @@ PlayerBoundingSphere::PlayerBoundingSphere(glm::vec3& min, glm::vec3& max) : Bou
 
 PlayerBoundingSphere::~PlayerBoundingSphere() {}
 
-// Checks if the BoundingBox intersects with the passed BoundingBox's coordinates
+// Checks if the BoundingSphere intersects with the passed BoundingBox's coordinates
 bool PlayerBoundingSphere::checkIntersection(std::shared_ptr<BoundingBox> other) {
-	//std::cout << "HERE" << std::endl;
-	// get box closest point to sphere center by clamping
+
+	// Find the closest point
 	float x = std::max(other->min_.x, std::min(center_.x, other->max_.x));
 	float y = std::max(other->min_.y, std::min(center_.y, other->max_.y));
 	float z = std::max(other->min_.z, std::min(center_.z, other->max_.z));
 
-	float distance = std::sqrt((x - center_.x) * (x - center_.x) +
+	glm::vec3 closestPointBoxToSphere(x, y, z);
+
+	// Check if the the distance to the closest point is smaller than the radius
+	float distance = glm::length(closestPointBoxToSphere - center_);
+	/*float distance = std::sqrt((x - center_.x) * (x - center_.x) +
 		(y - center_.y) * (y - center_.y) +
-		(z - center_.z) * (z - center_.z));
+		(z - center_.z) * (z - center_.z));*/
 
 	return distance < radius_;
 }
@@ -33,7 +37,6 @@ bool PlayerBoundingSphere::checkIntersection(std::shared_ptr<BoundingBox> other)
 // Updates the bounding box min, max, and boxPoints based on the passed transform
 void PlayerBoundingSphere::update(glm::mat4& transform) {
 	BoundingBox::update(transform);
-
 	center_ = transform * glm::vec4(objCenter_, 1.0);
 }
 

--- a/src/PlayerBoundingSphere.cpp
+++ b/src/PlayerBoundingSphere.cpp
@@ -27,9 +27,6 @@ bool PlayerBoundingSphere::checkIntersection(std::shared_ptr<BoundingBox> other)
 
 	// Check if the the distance to the closest point is smaller than the radius
 	float distance = glm::length(closestPointBoxToSphere - center_);
-	/*float distance = std::sqrt((x - center_.x) * (x - center_.x) +
-		(y - center_.y) * (y - center_.y) +
-		(z - center_.z) * (z - center_.z));*/
 
 	return distance < radius_;
 }

--- a/src/PlayerBoundingSphere.h
+++ b/src/PlayerBoundingSphere.h
@@ -1,0 +1,62 @@
+#ifndef BOUNDING_VOLUME_H
+#define BOUNDING_VOLUME_H
+
+#include "glm/glm.hpp"
+#include "glm/vec4.hpp"
+#include "glm/mat4x4.hpp"
+#include "glm/gtc/matrix_transform.hpp"
+
+#include <algorithm>
+#include <float.h>
+#include <iostream>
+
+#include "BoundingBox.h"
+
+class PlayerBoundingSphere : public BoundingBox {
+public:
+
+	glm::vec3 objCenter_;
+
+	glm::vec3 center_;
+
+	float radius_;
+
+	PlayerBoundingSphere() : BoundingBox() {
+		objCenter_ = (objMin_ + objMax_) / 2.0f;
+		center_ = objCenter_;
+		radius_ = abs(glm::length(objMax_ - center_));
+	}
+
+	PlayerBoundingSphere(glm::vec3& min, glm::vec3& max) : BoundingBox(min, max) {
+		std::cout << "HERFSXC" << std::endl;
+		objCenter_ = (min + max) / 2.0f;
+		center_ = objCenter_;
+		radius_ = abs(glm::length(max - center_));
+	}
+
+	~PlayerBoundingSphere() {}
+
+	// Checks if the BoundingBox intersects with the passed BoundingBox's coordinates
+	bool checkIntersection(BoundingBox& other) {
+		std::cout << "HERE" << std::endl;
+		// get box closest point to sphere center by clamping
+		float x = std::max(other.min_.x, std::min(center_.x, other.max_.x));
+		float y = std::max(other.min_.y, std::min(center_.y, other.max_.y));
+		float z = std::max(other.min_.z, std::min(center_.z, other.max_.z));
+
+		float distance = std::sqrt((x - center_.x) * (x - center_.x) +
+			(y - center_.y) * (y - center_.y) +
+			(z - center_.z) * (z - center_.z));
+
+		return distance < radius_;
+	}
+
+	// Updates the bounding box min, max, and boxPoints based on the passed transform
+	void update(glm::mat4& transform) {
+		BoundingBox::update(transform);
+
+		center_ = transform * glm::vec4(objCenter_, 1.0);
+	}
+};
+
+#endif

--- a/src/PlayerBoundingSphere.h
+++ b/src/PlayerBoundingSphere.h
@@ -1,5 +1,5 @@
-#ifndef BOUNDING_VOLUME_H
-#define BOUNDING_VOLUME_H
+#ifndef PLAYER_BOUNDING_SPHERE_H
+#define PLAYER_BOUNDING_SPHERE_H
 
 #include "glm/glm.hpp"
 #include "glm/vec4.hpp"

--- a/src/PlayerBoundingSphere.h
+++ b/src/PlayerBoundingSphere.h
@@ -21,42 +21,19 @@ public:
 
 	float radius_;
 
-	PlayerBoundingSphere() : BoundingBox() {
-		objCenter_ = (objMin_ + objMax_) / 2.0f;
-		center_ = objCenter_;
-		radius_ = abs(glm::length(objMax_ - center_));
-	}
+	PlayerBoundingSphere();
 
-	PlayerBoundingSphere(glm::vec3& min, glm::vec3& max) : BoundingBox(min, max) {
-		std::cout << "HERFSXC" << std::endl;
-		objCenter_ = (min + max) / 2.0f;
-		center_ = objCenter_;
-		radius_ = abs(glm::length(max - center_));
-	}
+	PlayerBoundingSphere(glm::vec3& min, glm::vec3& max);
 
-	~PlayerBoundingSphere() {}
+	~PlayerBoundingSphere();
 
 	// Checks if the BoundingBox intersects with the passed BoundingBox's coordinates
-	bool checkIntersection(BoundingBox& other) {
-		std::cout << "HERE" << std::endl;
-		// get box closest point to sphere center by clamping
-		float x = std::max(other.min_.x, std::min(center_.x, other.max_.x));
-		float y = std::max(other.min_.y, std::min(center_.y, other.max_.y));
-		float z = std::max(other.min_.z, std::min(center_.z, other.max_.z));
-
-		float distance = std::sqrt((x - center_.x) * (x - center_.x) +
-			(y - center_.y) * (y - center_.y) +
-			(z - center_.z) * (z - center_.z));
-
-		return distance < radius_;
-	}
+	bool checkIntersection(std::shared_ptr<BoundingBox> other);
 
 	// Updates the bounding box min, max, and boxPoints based on the passed transform
-	void update(glm::mat4& transform) {
-		BoundingBox::update(transform);
+	void update(glm::mat4& transform);
 
-		center_ = transform * glm::vec4(objCenter_, 1.0);
-	}
+	bool isPlayer();
 };
 
 #endif

--- a/src/PlayerBoundingSphere.h
+++ b/src/PlayerBoundingSphere.h
@@ -27,10 +27,11 @@ public:
 
 	~PlayerBoundingSphere();
 
-	// Checks if the BoundingBox intersects with the passed BoundingBox's coordinates
+	// Checks if the BoundingSphere intersects with the passed BoundingBox's coordinates
 	bool checkIntersection(std::shared_ptr<BoundingBox> other);
 
 	// Updates the bounding box min, max, and boxPoints based on the passed transform
+	// Also, updates the sphere center
 	void update(glm::mat4& transform);
 
 	bool isPlayer();

--- a/src/PlayerInputComponent.cpp
+++ b/src/PlayerInputComponent.cpp
@@ -36,6 +36,11 @@ void PlayerInputComponent::pollGamepad() {
     * For our purposes y-joy = x-world & x-joy = z-world
     */
    float xComponent = axes[1], zComponent = -axes[0];
+
+#ifdef _WIN32
+   xComponent = -xComponent;
+#endif
+
    // Two driving modes: reverse and drive.
    bool modeChangeAvailable = !holder_->toggleMovement;
 

--- a/src/PlayerPhysicsComponent.cpp
+++ b/src/PlayerPhysicsComponent.cpp
@@ -53,10 +53,6 @@ void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
             if (normalOfObjHit.z != 0.0f) {
                newPosition.z = oldPosition.z;
             }
-
-			if (normalOfObjHit.x != 0.0f && normalOfObjHit.z != 0.0f) {
-				newPosition = oldPosition + glm::normalize(glm::vec3(normalOfObjHit.x, 0.0f, normalOfObjHit.z)) * glm::vec3(5.0);
-			}
          }
          if (objTypeHit == GameObjectType::FINISH_OBJECT) {
             GameManager::instance().gameOver_ = true;

--- a/src/PlayerPhysicsComponent.cpp
+++ b/src/PlayerPhysicsComponent.cpp
@@ -10,8 +10,6 @@ PlayerPhysicsComponent::PlayerPhysicsComponent() {}
 PlayerPhysicsComponent::~PlayerPhysicsComponent() {}
 
 void PlayerPhysicsComponent::initBoundingBox(glm::vec3& minBoundPt, glm::vec3& maxBoundPt) {
-	std::cout << "HERE@@" << std::endl;
-
 #ifdef USE_PLAYER_BOUNDING_SPHERE
 	boundBox_ = std::make_shared<PlayerBoundingSphere>(PlayerBoundingSphere(minBoundPt, maxBoundPt));
 #else
@@ -41,7 +39,7 @@ void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
          GameObjectType objTypeHit = objHit->type;
 
          if (objTypeHit == GameObjectType::STATIC_OBJECT) {
-			 std::shared_ptr<BoundingBox> objHitBB = objHit->getBoundingBox();
+            std::shared_ptr<BoundingBox> objHitBB = objHit->getBoundingBox();
             glm::vec3 normalOfObjHit = objHitBB->calcReflNormal(getBoundingBox(), 0.1f);
 
             if (normalOfObjHit.x != 0.0f) {
@@ -56,9 +54,9 @@ void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
                newPosition.z = oldPosition.z;
             }
 
-			/*if (normalOfObjHit.x != 0.0f && normalOfObjHit.z != 0.0f) {
+			if (normalOfObjHit.x != 0.0f && normalOfObjHit.z != 0.0f) {
 				newPosition = oldPosition + glm::normalize(glm::vec3(normalOfObjHit.x, 0.0f, normalOfObjHit.z)) * glm::vec3(5.0);
-			}*/
+			}
          }
          if (objTypeHit == GameObjectType::FINISH_OBJECT) {
             GameManager::instance().gameOver_ = true;

--- a/src/PlayerPhysicsComponent.cpp
+++ b/src/PlayerPhysicsComponent.cpp
@@ -3,10 +3,17 @@
 #include "GameManager.h"
 #include "GameObject.h"
 #include "GameWorld.h"
+#include "PlayerBoundingSphere.h"
 
 PlayerPhysicsComponent::PlayerPhysicsComponent() {}
 
 PlayerPhysicsComponent::~PlayerPhysicsComponent() {}
+
+void PlayerPhysicsComponent::initBoundingBox(glm::vec3& minBoundPt, glm::vec3& maxBoundPt) {
+	std::cout << "HERE@@" << std::endl;
+	boundBox_ = PlayerBoundingSphere(minBoundPt, maxBoundPt);
+	updateBoundingBox();
+}
 
 void PlayerPhysicsComponent::initObjectPhysics() {
    updateBoundingBox();
@@ -42,6 +49,10 @@ void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
             if (normalOfObjHit.z != 0.0f) {
                newPosition.z = oldPosition.z;
             }
+
+			/*if (normalOfObjHit.x != 0.0f && normalOfObjHit.z != 0.0f) {
+				newPosition = oldPosition + glm::normalize(glm::vec3(normalOfObjHit.x, 0.0f, normalOfObjHit.z)) * glm::vec3(5.0);
+			}*/
          }
          if (objTypeHit == GameObjectType::FINISH_OBJECT) {
             GameManager::instance().gameOver_ = true;

--- a/src/PlayerPhysicsComponent.cpp
+++ b/src/PlayerPhysicsComponent.cpp
@@ -11,7 +11,13 @@ PlayerPhysicsComponent::~PlayerPhysicsComponent() {}
 
 void PlayerPhysicsComponent::initBoundingBox(glm::vec3& minBoundPt, glm::vec3& maxBoundPt) {
 	std::cout << "HERE@@" << std::endl;
-	boundBox_ = PlayerBoundingSphere(minBoundPt, maxBoundPt);
+
+#ifdef USE_PLAYER_BOUNDING_SPHERE
+	boundBox_ = std::make_shared<PlayerBoundingSphere>(PlayerBoundingSphere(minBoundPt, maxBoundPt));
+#else
+	boundBox_ = std::make_shared<BoundingBox>(BoundingBox(minBoundPt, maxBoundPt));
+#endif
+
 	updateBoundingBox();
 }
 
@@ -35,8 +41,8 @@ void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
          GameObjectType objTypeHit = objHit->type;
 
          if (objTypeHit == GameObjectType::STATIC_OBJECT) {
-            BoundingBox* objHitBB = objHit->getBoundingBox();
-            glm::vec3 normalOfObjHit = objHitBB->calcReflNormal(getBoundingBox());
+			 std::shared_ptr<BoundingBox> objHitBB = objHit->getBoundingBox();
+            glm::vec3 normalOfObjHit = objHitBB->calcReflNormal(getBoundingBox(), 0.1f);
 
             if (normalOfObjHit.x != 0.0f) {
                newPosition.x = oldPosition.x;

--- a/src/PlayerPhysicsComponent.h
+++ b/src/PlayerPhysicsComponent.h
@@ -9,6 +9,8 @@ public:
 
    ~PlayerPhysicsComponent();
 
+   void initBoundingBox(glm::vec3& minBoundPt, glm::vec3& maxBoundPt);
+
    void initObjectPhysics();
 
    void updatePhysics(float deltaTime);

--- a/src/ViewFrustum.cpp
+++ b/src/ViewFrustum.cpp
@@ -75,8 +75,8 @@ bool ViewFrustum::cull(std::shared_ptr<GameObject> obj) {
    /* Every object needs to have a bounding box in order to cull.
     * If an object doesn't have a bounding box, cull it so we don't create
     * unseen problems with culling. */
-   BoundingBox* objBox = obj->getBoundingBox();
-   if (objBox == NULL) {
+   std::shared_ptr<BoundingBox> objBox = obj->getBoundingBox();
+   if (objBox == nullptr) {
       return false;
    }
    vec3 box[] = {objBox->min_, objBox->max_};


### PR DESCRIPTION
Okay, so this has two things going on here mainly:

1. Reduce the epsilon in the reflection test for player collisions and turn off the BB update on rotation functionality
2. A mode for the player that uses bounding spheres

Please try both versions out (there's a #define in PlayerPhysicsComponent called `USE_PLAYER_BOUNDING_SPHERE` (just comment out to set the boundBox to the sphere variant).  I think 1 is significantly better, but 2 could be improved with additional effort, not sure yet.

I think 1 is a significant improvement (again) but please try out and let me know - not going for perfect here, but should be improved a lot.