### PR TITLE
Power-Ups

### DIFF
--- a/src/FireHydrantPhysicsComponent.cpp
+++ b/src/FireHydrantPhysicsComponent.cpp
@@ -101,6 +101,9 @@ void FireHydrantPhysicsComponent::updatePhysics(float deltaTime) {
                untouched = false;
             }
 
+            // Initialize the power-up
+            objHit->initPowerup("speed", 3.0);
+
          } else if (objTypeHit == GameObjectType::STATIC_OBJECT ||
                     objTypeHit == GameObjectType::DYNAMIC_OBJECT) {
             std::shared_ptr<BoundingBox> objBB = objHit->getBoundingBox();

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -27,6 +27,8 @@ GameObject::GameObject(GameObjectType objType,
    fracture(false),
 	orientAngle_(0),
 	yRotationAngle_(0),
+   maxForwardVel(12.0f),
+   maxBackwardVel(5.0f),
 	render_(render),
 	input_(input),
 	physics_(physics),
@@ -165,6 +167,9 @@ void GameObject::update(double deltaTime) {
     if (cookieDeliverable) {
         arrow_->update(deltaTime);
     }
+
+   // Currently only used for PLAYER types to update internal power state
+   updatePowerups(deltaTime);
 }
 
 void GameObject::draw(std::shared_ptr<MatrixStack> P, std::shared_ptr<MatrixStack> M, std::shared_ptr<MatrixStack> V) {
@@ -304,4 +309,18 @@ std::shared_ptr<std::vector<glm::vec3>> GameObject::getFragmentDirs() {
 
 std::shared_ptr<std::vector<glm::vec3>> GameObject::getFragmentPos() {
    return fragPos_;
+}
+
+void GameObject::initPowerup(std::string type, float time) {
+   if (type == "speed") {
+      speedPowerRemaining = time;
+      maxForwardVel = 18.0f;
+   }
+}
+
+void GameObject::updatePowerups(double deltaTime) {
+   speedPowerRemaining -= deltaTime;
+   if (speedPowerRemaining < 0) {
+      maxForwardVel = 12.0f;
+   }
 }

--- a/src/GameObject.h
+++ b/src/GameObject.h
@@ -27,6 +27,8 @@ public:
 	float velocity;
 	MatrixTransform transform;
 	GameObjectType type;
+   float maxForwardVel;
+   float maxBackwardVel;
 
     // Properties for player moveable objects
     bool toggleMovement;
@@ -119,6 +121,9 @@ public:
     // TRY TO AVOID USING THIS IF POSSIBLE, SHOULD BE REMOVED AT SOME POINT, BB LOGIC ONLY IN PHYSICSCOMPONENT
     std::shared_ptr<BoundingBox> getBoundingBox();
 
+   // Initializes a new powerup that is held in the GameObject internal state
+   void initPowerup(std::string type, float time);
+
 private:
 
     // The current position of the object in world space
@@ -157,6 +162,9 @@ private:
     // The fractured objects current position.
     std::shared_ptr<std::vector<glm::vec3>> fragPos_;
 
+    // Power-up state and modifiers
+    double speedPowerRemaining;
+    void updatePowerups(double detlaTime);
 };
 
 #endif

--- a/src/PlayerInputComponent.cpp
+++ b/src/PlayerInputComponent.cpp
@@ -64,12 +64,12 @@ void PlayerInputComponent::pollGamepad() {
       // Determine driving mode and set velocity based on mode.
       if ((modeChangeAvailable && xComponent > 0) || inReverse) {
          inReverse = true;
-         holder_->velocity = magnitude * -5.0f; // Reverse
+         holder_->velocity = magnitude * -holder_->maxBackwardVel; // Reverse
 
          camera.calcCamAndPlayerOrient(dirGamepad, true);
       } else {
          inReverse = false;
-         holder_->velocity = magnitude * 12.0f; // Drive
+         holder_->velocity = magnitude * holder_->maxForwardVel; // Drive
 
          camera.calcCamAndPlayerOrient(dirGamepad, false);
       }


### PR DESCRIPTION
Added powerup when the user hits a firehydrant, it speeds them up for 3 seconds. It may need some visual feedback for 100% but right now it looks fine. People might not like it though we may need to change it to be a mega cookie or something.

It is pretty hacky but I don't want to restructure everything. So in the GameObject it just has different powerup states and a in the physics component you can say `initPowerup` and specify a string representing the type and a time that it lasts. Adding new powerups will be done inside the GameObject.