### PR TITLE
The restart button on the loss screen now causes the player to go into a "free roam" mode

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -205,9 +205,25 @@ void Menu::selectedItemDown() {
 void Menu::performMenuAction() {
     //TODO(nurgan) check for state
     if(selectedMenuItem == 0) {
-        toggleMenuActive();
-        leftMenuThisFrame_ = true;
-        menuTime_ = glfwGetTime() - menuStartTime_;
+		if (currentMenu == winMenu) {
+			WindowManager::instance().close();
+		}
+		else {
+			toggleMenuActive();
+			leftMenuThisFrame_ = true;
+			menuTime_ = glfwGetTime() - menuStartTime_;
+
+			GameManager& gameManager = GameManager::instance();
+			if (currentMenu == lostMenu && gameManager.getTime() <= 0.0f) {
+
+				// If the player has lost due to running out of time let them continue to explore
+				// but nullify the run
+				gameManager.increaseTime(9999.0f);
+				gameManager.reportScore(-999999.0f);
+				gameManager.gameOver_ = false;
+				setPauseMenu();
+			}
+		}
     } else if(selectedMenuItem == 1) {
         WindowManager::instance().close();
     }

--- a/src/PlayerPhysicsComponent.cpp
+++ b/src/PlayerPhysicsComponent.cpp
@@ -57,7 +57,13 @@ void PlayerPhysicsComponent::updatePhysics(float deltaTime) {
             }
          }
          if (objTypeHit == GameObjectType::FINISH_OBJECT) {
-            GameManager::instance().gameOver_ = true;
+			 GameManager& gameManager = GameManager::instance();
+			gameManager.gameOver_ = true;
+
+			if (gameManager.getScore() < 0) {
+				// If the player has a negative score, don't give a time bonus
+				gameManager.setTime(1.0f);
+			}
          }
       }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,9 +115,7 @@ int main(int argc, char **argv) {
 
     audioManager.startSoundtrack();
 
-
     while (!windowManager.isClosed()) {
-
 
         // Poll for and process events
         windowManager.pollEvents();
@@ -144,7 +142,6 @@ int main(int argc, char **argv) {
                     gameManager.showScore();
                     //return EXIT_SUCCESS;
                 }
-
 
                 elapsedTime -= deltaTime;
                 totalTime += deltaTime;


### PR DESCRIPTION
Also, the restart button on win causes the program to quit

So as I'll mention in slack, restart doesn't seem like it's something that is doable in a few hours (it's on the same scale as supporting multiple levels in my mind, same issues present in both features).  Maybe it's super easy and I'm just terrible - also a possibility :)

Anyway, something that was doable for me on short notice was just pumping up the time and dumping the player's score to allow the player to continue to explore in a "free roam" mode.  I noticed the time requirement is tuned pretty well, but I have a feeling some players will just wanna run around and knock into stuff at their pace.  This lets them do that and gives us a reason for two options (except on the win screen).

Obviously, restart would be nice (even in addition) but if Alex has time to change the menu textures, hopefully, this is a reasonable substitute.   Or maybe 4am Reed is dumb : P either way check it out if we've still got some time before tomorrows presentation.

Action items needed alongside this if we want it:
+ Win screen duplicate with only an "Exit" option (as a way to fit within the existing menu code)
+ Lose screen with "Free Roam" or similar replacing "Restart"

Action items needed if we don't want this:
+ Remove "Restart" from both win and lose and just have two identical images with the "Exit" option to fit within existing menu code

P.S. If this is garbage because I'm tired right now, just tell me, 5am Reed finds this neato